### PR TITLE
Barcode clock-in

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # About
 
-This project is PHP Timeclock v1.04 with the Punchclock v0.8 add-on already installed.
+This project is PHP Timeclock with the Punchclock add-on already installed.
 
 # This Fork
 
@@ -56,8 +56,6 @@ Punchclock enhances PHP Timeclock with 5 extra features:
  - Flexible export to your spreadsheet or business software.
     
 ## PHP Timeclock source credits
-- Version 1.04
-- http://sourceforge.net/projects/timeclock
 - Copyright (C) 2006 Ken Papizan <pappyzan_at_users.sourceforge.net>
 
 
@@ -102,7 +100,7 @@ version than what's tested or later, will probably work fine.
     certain users can run them, then give these users reports level access. 
 
 
-### Migration from another verison of 1.04 (ie: old official release)
+### Migration from another verison (ie: old official release)
 
  -  Backup your current install directory and database.
  -  Delete all files in your current install directory.

--- a/admin/dbupgrade.php
+++ b/admin/dbupgrade.php
@@ -6,6 +6,73 @@ include 'header.php';
 include 'topmain.php';
 echo "<title>$title - Upgrade Database</title>\n";
 
+function msg_changed($msg) {
+    echo "<tr><td width=10 class=table_rows style='padding-left:25px;color:#0000FF;font-weight:bold;'>Changed</td><td class=table_rows align=left>:&nbsp;$msg</td></tr>\n";
+}
+
+function msg_added($msg) {
+    echo "<tr><td width=10 class=table_rows style='padding-left:25px;color:#FF9900;font-weight:bold;'>Added</td><td class=table_rows align=left>:&nbsp;$msg</td></tr>\n";
+}
+
+function msg_converted($msg) {
+    echo "<tr><td width=10 class=table_rows style='padding-left:25px;color:#FF9900;font-weight:bold;'>Converted</td><td class=table_rows align=left>:&nbsp;$msg</td></tr>\n";
+}
+
+// Ensure that the corresponding table exists, creates it if missing.
+// Note: need not create all columns since we will add any missing columns
+// with ensure_field.
+function ensure_table($table, $columns, $engine = "ENGINE=MyISAM DEFAULT CHARSET=utf8 COLLATE=utf8_bin") {
+    global $db_name;
+    global $db_prefix;
+    $rows = mysqli_num_rows(tc_query("SHOW TABLES LIKE '$db_prefix$table'"));
+
+    if (empty($rows)) {
+        tc_query("CREATE TABLE $db_prefix$table ($columns) $engine");
+        msg_added("<b>$table</b> table has been added to the <u>$db_name</u> database.");
+        return 1;
+    }
+    return 0;
+}
+
+// Ensure field is present and has correct type. Does not check other
+// attributes (NULL, default, ...)
+function ensure_field($table, $field, $type, $extra) {
+    global $db_prefix;
+    $result = tc_query("SHOW FIELDS FROM $db_prefix$table LIKE '$field'");
+
+    while ($row = mysqli_fetch_array($result)) {
+        $current_type = "" . $row['Type'] . "";
+        if (strtolower($type) !== strtolower($current_type)) {
+            tc_query("ALTER TABLE $db_prefix$table CHANGE `$field` `$field` $type $extra");
+            msg_changed("<b>$field</b> field in <u>$table</u> table has been changed from type $current_type to type $type.");
+            return 1;
+        }
+    }
+
+    if (empty($current_type)) {
+        tc_query("ALTER TABLE $db_prefix$table ADD `$field` $type $extra;");
+        msg_added("<b>$field</b> field has been added to the <u>$table</u> table.");
+        return 1;
+    }
+
+    return 0;
+}
+
+// Ensure a simple non-primary/non-unique index is present on the named
+// field. If a primary/unique index exists, we won't create another.
+function ensure_index($table, $field) {
+    global $db_prefix;
+    $rows = mysqli_num_rows(tc_query("SHOW INDEX FROM $db_prefix$table WHERE column_name = ?", $field));
+
+    if (empty($rows)) {
+        tc_query("CREATE INDEX {$db_prefix}{$table}_{$field} ON {$db_prefix}{$table} (`{$field}`)");
+        msg_added("INDEX has been added to the <u>{$table}.{$field}</u> column.");
+        return 1;
+    }
+    return 0;
+}
+
+
 $self = $_SERVER['PHP_SELF'];
 $request = $_SERVER['REQUEST_METHOD'];
 
@@ -22,11 +89,7 @@ if (!isset($_SESSION['valid_user'])) {
     exit;
 }
 
-$count = "0";
-$tmp_count = "0";
-$emp_tstamp_count = "0";
-$info_timestamp_count = "0";
-$passed_or_not = "0";
+$changes_made = 0;
 $gmt_offset = date('Z');
 
 echo "<table width=100% height=89% border=0 cellpadding=0 cellspacing=1>\n";
@@ -77,29 +140,26 @@ echo "            <br />\n";
 
 // determine the privileges of the PHP Timeclock user //
 
-$result = mysqli_query($GLOBALS["___mysqli_ston"], "show grants for current_user()");
+$count = "0";
+$result = tc_query("show grants for current_user()");
 while ($row = mysqli_fetch_array($result)) {
     $abc = stripslashes("" . $row["0"] . "");
     if (((preg_match("/\bgrant\b/i", $abc)) && (preg_match("/\bselect\b/i", $abc)) &&
          (preg_match("/\binsert\b/i", $abc)) && (preg_match("/\bupdate\b/i", $abc)) &&
          (preg_match("/\bdelete\b/i", $abc)) && (preg_match("/\bcreate\b/i", $abc)) &&
-         (preg_match("/\balter\b/i", $abc)) && (preg_match("/\bon `$db_name`\.\* to '$db_username'@'$db_hostname|%\b/i", $abc))) ||
-        (preg_match("/\bgrant all privileges on `$db_name`\.\* to '$db_username'@'$db_hostname|%' \b/i", $abc)) ||
-        (preg_match("/\bgrant all privileges on \*\.\* to '$db_username'@'$db_hostname|%' \b/i", $abc))
+         (preg_match("/\balter\b/i", $abc)) && (preg_match("/\bon `\Q$db_name`.*\E to '\Q$db_username\E'@/i", $abc))) ||
+        (preg_match("/\bgrant all privileges on \Q`$db_name`.*\E to '\Q$db_username\E'@'/i", $abc)) ||
+        (preg_match("/\bgrant all privileges on \*\.\* to '\Q$db_username\E'@/i", $abc))
     ) {
         $count++;
     }
 }
+
 if (!empty($count)) {
 
     if ($request == 'GET') {
 
-        $query_admin = "select empfullname from " . $db_prefix . "employees where empfullname = 'admin'";
-        $result_admin = mysqli_query($GLOBALS["___mysqli_ston"], $query_admin);
-
-        while ($row = mysqli_fetch_array($result_admin)) {
-            $user_admin = "" . $row["empfullname"] . "";
-        }
+        $user_admin = tc_select_value("empfullname", "employees", "empfullname = 'admin'");
 
         echo "            <form name='form' action='$self' method='post'>\n";
         echo "            <table align=center class=table_border width=60% border=0 cellpadding=3 cellspacing=0>\n";
@@ -153,360 +213,158 @@ if (!empty($count)) {
         echo "              <tr><td height=15></td></tr>\n";
 
 
-        // track the database changes that have been made since version 0.9 //
+        // TABLE: audit //
+        $changes_made += ensure_table("audit", "modified_when bigint(14)");
 
-        // employees table additions //
+        $changes_made += ensure_field("audit", "modified_when",    "bigint(14)",   "");
+        $changes_made += ensure_field("audit", "modified_from",    "bigint(14)",   "NOT NULL");
+        $changes_made += ensure_field("audit", "modified_to",      "bigint(14)",   "NOT NULL");
+        $changes_made += ensure_field("audit", "modified_by_ip",   "varchar(39)",  "COLLATE utf8_bin NOT NULL DEFAULT ''");
+        $changes_made += ensure_field("audit", "modified_by_user", "varchar(50)",  "COLLATE utf8_bin NOT NULL DEFAULT ''");
+        $changes_made += ensure_field("audit", "modified_why",     "varchar(250)", "COLLATE utf8_bin NOT NULL DEFAULT ''");
+        $changes_made += ensure_field("audit", "user_modified",    "varchar(50)",  "COLLATE utf8_bin NOT NULL DEFAULT ''");
 
-        $field = "employee_passwd";
-        $result = mysqli_query($GLOBALS["___mysqli_ston"], "SHOW fields from " . $db_prefix . "employees LIKE '" . $field . "'");
-        @$rows = mysqli_num_rows($result);
+        $changes_made += ensure_index("audit", "modified_when");
 
-        if (empty($rows)) {
-            $passwd_query = mysqli_query($GLOBALS["___mysqli_ston"], "ALTER TABLE " . $db_prefix . "employees ADD $field VARCHAR(25) NOT NULL;");
-            echo "              <tr><td width=10 class=table_rows style='padding-left:25px;color:#FF9900;font-weight:bold;'>Added</td><td class=table_rows
-                      align=left>:&nbsp;<b>$field</b> field has been added to the <u>employees</u> table.</td></tr>\n";
-            $passed_or_not = "1";
-        }
+        // TABLE: employees //
+        $changes_made += ensure_table("employees", "empfullname varchar(50) PRIMARY KEY COLLATE utf8_bin");
 
-        $field = "displayname";
-        $result = mysqli_query($GLOBALS["___mysqli_ston"], "SHOW fields from " . $db_prefix . "employees LIKE '" . $field . "'");
-        @$rows = mysqli_num_rows($result);
-
-        if (empty($rows)) {
-            $passwd_query = mysqli_query($GLOBALS["___mysqli_ston"], "ALTER TABLE " . $db_prefix . "employees ADD $field VARCHAR(50) NOT NULL;");
-            echo "              <tr><td width=10 class=table_rows style='padding-left:25px;color:#FF9900;font-weight:bold;'>Added</td><td class=table_rows
-                      align=left>:&nbsp;<b>$field</b> field has been added to the <u>employees</u> table.</td></tr>\n";
-            $passed_or_not = "1";
-        }
-
-        $field = "email";
-        $result = mysqli_query($GLOBALS["___mysqli_ston"], "SHOW fields from " . $db_prefix . "employees LIKE '" . $field . "'");
-        @$rows = mysqli_num_rows($result);
-
-        if (empty($rows)) {
-            $passwd_query = mysqli_query($GLOBALS["___mysqli_ston"], "ALTER TABLE " . $db_prefix . "employees ADD $field VARCHAR(75) NOT NULL;");
-            echo "              <tr><td width=10 class=table_rows style='padding-left:25px;color:#FF9900;font-weight:bold;'>Added</td><td class=table_rows
-                      align=left>:&nbsp;<b>$field</b> field has been added to the <u>employees</u> table.</td></tr>\n";
-            $passed_or_not = "1";
-        }
-
-        $field = "groups";
-        $result = mysqli_query($GLOBALS["___mysqli_ston"], "SHOW fields from " . $db_prefix . "employees LIKE '" . $field . "'");
-        @$rows = mysqli_num_rows($result);
-
-        if (empty($rows)) {
-            $passwd_query = mysqli_query($GLOBALS["___mysqli_ston"], "ALTER TABLE " . $db_prefix . "employees ADD $field VARCHAR(50) NOT NULL;");
-            echo "              <tr><td width=10 class=table_rows style='padding-left:25px;color:#FF9900;font-weight:bold;'>Added</td><td class=table_rows
-                      align=left>:&nbsp;<b>$field</b> field has been added to the <u>employees</u> table.</td></tr>\n";
-            $passed_or_not = "1";
-        }
-
-        $field = "office";
-        $result = mysqli_query($GLOBALS["___mysqli_ston"], "SHOW fields from " . $db_prefix . "employees LIKE '" . $field . "'");
-        @$rows = mysqli_num_rows($result);
-
-        if (empty($rows)) {
-            $passwd_query = mysqli_query($GLOBALS["___mysqli_ston"], "ALTER TABLE " . $db_prefix . "employees ADD $field VARCHAR(50) NOT NULL;");
-            echo "              <tr><td width=10 class=table_rows style='padding-left:25px;color:#FF9900;font-weight:bold;'>Added</td><td class=table_rows
-                      align=left>:&nbsp;<b>$field</b> field has been added to the <u>employees</u> table.</td></tr>\n";
-            $passed_or_not = "1";
-        }
-
-        $field = "admin";
-        $result = mysqli_query($GLOBALS["___mysqli_ston"], "SHOW fields from " . $db_prefix . "employees LIKE '" . $field . "'");
-        @$rows = mysqli_num_rows($result);
-
-        if (empty($rows)) {
-            $passwd_query = mysqli_query($GLOBALS["___mysqli_ston"], "ALTER TABLE " . $db_prefix . "employees ADD $field TINYINT(1) NOT NULL default '0';");
-            echo "              <tr><td width=10 class=table_rows style='padding-left:25px;color:#FF9900;font-weight:bold;'>Added</td><td class=table_rows
-                      align=left>:&nbsp;<b>$field</b> field has been added to the <u>employees</u> table.</td></tr>\n";
-            $passed_or_not = "1";
-        }
-
-        $field = "reports";
-        $result = mysqli_query($GLOBALS["___mysqli_ston"], "SHOW fields from " . $db_prefix . "employees LIKE '" . $field . "'");
-        @$rows = mysqli_num_rows($result);
-
-        if (empty($rows)) {
-            $passwd_query = mysqli_query($GLOBALS["___mysqli_ston"], "ALTER TABLE " . $db_prefix . "employees ADD $field TINYINT(1) NOT NULL default '0';");
-            echo "              <tr><td width=10 class=table_rows style='padding-left:25px;color:#FF9900;font-weight:bold;'>Added</td><td class=table_rows
-                      align=left>:&nbsp;<b>$field</b> field has been added to the <u>employees</u> table.</td></tr>\n";
-            $passed_or_not = "1";
-        }
-
-        $field = "time_admin";
-        $result = mysqli_query($GLOBALS["___mysqli_ston"], "SHOW fields from " . $db_prefix . "employees LIKE '" . $field . "'");
-        @$rows = mysqli_num_rows($result);
-
-        if (empty($rows)) {
-            $passwd_query = mysqli_query($GLOBALS["___mysqli_ston"], "ALTER TABLE " . $db_prefix . "employees ADD $field TINYINT(1) NOT NULL default '0';");
-            echo "              <tr><td width=10 class=table_rows style='padding-left:25px;color:#FF9900;font-weight:bold;'>Added</td><td class=table_rows
-                      align=left>:&nbsp;<b>$field</b> field has been added to the <u>employees</u> table.</td></tr>\n";
-            $passed_or_not = "1";
-        }
-
-        $field = "disabled";
-        $result = mysqli_query($GLOBALS["___mysqli_ston"], "SHOW fields from " . $db_prefix . "employees LIKE '" . $field . "'");
-        @$rows = mysqli_num_rows($result);
-
-        if (empty($rows)) {
-            $passwd_query = mysqli_query($GLOBALS["___mysqli_ston"], "ALTER TABLE " . $db_prefix . "employees ADD $field TINYINT(1) NOT NULL default '0';");
-            echo "              <tr><td width=10 class=table_rows style='padding-left:25px;color:#FF9900;font-weight:bold;'>Added</td><td class=table_rows
-                      align=left>:&nbsp;<b>$field</b> field has been added to the <u>employees</u> table.</td></tr>\n";
-            $passed_or_not = "1";
-        }
-
-        // employees table changes //
-
-        $result = mysqli_query($GLOBALS["___mysqli_ston"], "SHOW FIELDS FROM " . $db_prefix . "employees");
+        $result = tc_query("SHOW FIELDS FROM {$db_prefix}employees");
         while ($row = mysqli_fetch_array($result)) {
             $name = "" . $row["Field"] . "";
-            $type = "" . $row["Type"] . "";
-            $tmp_type = strtoupper($type);
+            $type = strtolower("" . $row["Type"] . "");
 
-            if (($name == 'empfullname') && ($type != 'varchar(50)')) {
-                $alter_result = mysqli_query($GLOBALS["___mysqli_ston"], "ALTER TABLE " . $db_prefix . "employees CHANGE empfullname empfullname VARCHAR(50) NOT NULL");
-                echo "              <tr><td width=10 class=table_rows style='padding-left:25px;color:#0000FF;font-weight:bold;'>Changed</td><td class=table_rows
-                      align=left>:&nbsp;<b>$name</b> field in <u>employees</u> table has been changed from type $tmp_type to type VARCHAR(50).</td></tr>\n";
-                $passed_or_not = "1";
-            }
+            // This one needs some data conversion:
             if (($name == 'tstamp') && ($type != 'bigint(14)')) {
-                $alter_result = mysqli_query($GLOBALS["___mysqli_ston"], "ALTER TABLE " . $db_prefix . "employees CHANGE tstamp tstamp BIGINT(14) DEFAULT NULL");
-                echo "              <tr><td width=10 class=table_rows style='padding-left:25px;color:#0000FF;font-weight:bold;'>Changed</td><td class=table_rows
-                      align=left>:&nbsp;<b>$name</b> field in <u>employees</u> table has been changed from type $tmp_type to type BIGINT(14).</td></tr>\n";
-                $emp_tstamp_count++;
-                $passed_or_not = "1";
+                tc_query("ALTER TABLE {$db_prefix}employees CHANGE tstamp tstamp BIGINT(14) DEFAULT NULL");
+                msg_changed("<b>$name</b> field in <u>employees</u> table has been changed from type $type to type BIGINT(14).");
+                $changes_made += 1;
+
+                tc_query("UPDATE {$db_prefix}employees SET tstamp = (unix_timestamp(tstamp) - '$gmt_offset')");
+                $num_rows = mysqli_affected_rows($GLOBALS["___mysqli_ston"]);
+                if (!empty($num_rows)) {
+                    msg_converted("<b>$num_rows rows</b> in the employees table were converted from a mysql timestamp to a unix timestamp.");
+                }
             }
         }
-        ((mysqli_free_result($result) || (is_object($result) && (get_class($result) == "mysqli_result"))) ? true : false);
 
-        // info table additions //
+        $changes_made += ensure_field("employees", "empfullname",      "varchar(50)", "PRIMARY KEY COLLATE utf8_bin");
+        $changes_made += ensure_field("employees", "tstamp",           "bigint(14)",  "DEFAULT NULL");
+        $changes_made += ensure_field("employees", "employee_passwd",  "varchar(25)", "COLLATE utf8_bin NOT NULL DEFAULT ''");
+        $changes_made += ensure_field("employees", "displayname",      "varchar(50)", "COLLATE utf8_bin NOT NULL DEFAULT ''");
+        $changes_made += ensure_field("employees", "email",            "varchar(75)", "COLLATE utf8_bin NOT NULL DEFAULT ''");
+        $changes_made += ensure_field("employees", "groups",           "varchar(50)", "COLLATE utf8_bin NOT NULL DEFAULT ''");
+        $changes_made += ensure_field("employees", "office",           "varchar(50)", "COLLATE utf8_bin NOT NULL DEFAULT ''");
+        $changes_made += ensure_field("employees", "admin",            "tinyint(1)",  "NOT NULL DEFAULT '0'");
+        $changes_made += ensure_field("employees", "reports",          "tinyint(1)",  "NOT NULL DEFAULT '0'");
+        $changes_made += ensure_field("employees", "time_admin",       "tinyint(1)",  "NOT NULL DEFAULT '0'");
+        $changes_made += ensure_field("employees", "disabled",         "tinyint(1)",  "NOT NULL DEFAULT '0'");
 
-        $field = "ipaddress";
-        $result = mysqli_query($GLOBALS["___mysqli_ston"], "SHOW fields from " . $db_prefix . "info LIKE '" . $field . "'");
-        @$rows = mysqli_num_rows($result);
 
-        if (empty($rows)) {
-            $passwd_query = mysqli_query($GLOBALS["___mysqli_ston"], "ALTER TABLE " . $db_prefix . "info ADD $field VARCHAR(39) NOT NULL;");
-            echo "              <tr><td width=10 class=table_rows style='padding-left:25px;color:#FF9900;font-weight:bold;'>Added</td><td class=table_rows
-                      align=left>:&nbsp;<b>$field</b> field has been added to the <u>employees</u> table.</td></tr>\n";
-            $passed_or_not = "1";
-        }
+        // TABLE: groups //
+        $changes_made += ensure_table("groups", "groupid int(10) AUTO_INCREMENT PRIMARY KEY");
 
-        // info table changes //
+        $changes_made += ensure_field("groups", "groupid",   "int(10)",     "AUTO_INCREMENT PRIMARY KEY");
+        $changes_made += ensure_field("groups", "groupname", "varchar(50)", "COLLATE utf8_bin NOT NULL DEFAULT ''");
+        $changes_made += ensure_field("groups", "officeid",  "int(10)",     "NOT NULL DEFAULT '0'");
 
-        $result = mysqli_query($GLOBALS["___mysqli_ston"], "SHOW FIELDS FROM " . $db_prefix . "info");
+
+        // TABLE: info //
+        $changes_made += ensure_table("info", "fullname varchar(50) COLLATE utf8_bin NOT NULL DEFAULT ''");
+
+        $result = tc_query("SHOW FIELDS FROM {$db_prefix}info");
         while ($row = mysqli_fetch_array($result)) {
             $name = "" . $row["Field"] . "";
-            $type = "" . $row["Type"] . "";
-            $tmp_type = strtoupper($type);
+            $type = strtolower("" . $row["Type"] . "");
 
-            if (($name == 'inout') && ($type != 'varchar(50)')) {
-                $alter_result = mysqli_query($GLOBALS["___mysqli_ston"], "ALTER TABLE " . $db_prefix . "info CHANGE `inout` `inout` VARCHAR(50) NOT NULL");
-                echo "              <tr><td width=10 class=table_rows style='padding-left:25px;color:#0000FF;font-weight:bold;'>Changed</td><td class=table_rows
-                      align=left>:&nbsp;<b>$name</b> field in <u>info</u> table has been changed from type $tmp_type to type VARCHAR(50).</td></tr>\n";
-                $passed_or_not = "1";
-            }
+            // This one needs some data conversion:
             if (($name == 'timestamp') && ($type != 'bigint(14)')) {
-                $alter_result = mysqli_query($GLOBALS["___mysqli_ston"], "ALTER TABLE " . $db_prefix . "info CHANGE timestamp timestamp BIGINT(14) DEFAULT NULL");
-                echo "              <tr><td width=10 class=table_rows style='padding-left:25px;color:#0000FF;font-weight:bold;'>Changed</td><td class=table_rows
-                      align=left>:&nbsp;<b>$name</b> field in <u>info</u> table has been changed from type $tmp_type to type BIGINT(14).</td></tr>\n";
-                $info_timestamp_count++;
-                $passed_or_not = "1";
-            }
-        }
-        ((mysqli_free_result($result) || (is_object($result) && (get_class($result) == "mysqli_result"))) ? true : false);
+                tc_query("ALTER TABLE {$db_prefix}info CHANGE timestamp timestamp BIGINT(14) DEFAULT NULL");
+                msg_changed("<b>$name</b> field in <u>info</u> table has been changed from type $type to type BIGINT(14).");
+                $changes_made += 1;
 
-        // punchlist table additions //
-
-        $field = "in_or_out";
-        $result = mysqli_query($GLOBALS["___mysqli_ston"], "SHOW fields from " . $db_prefix . "punchlist LIKE '" . $field . "'");
-        $rows = mysqli_num_rows($result);
-
-        if (empty($rows)) {
-            $passwd_query = mysqli_query($GLOBALS["___mysqli_ston"], "ALTER TABLE " . $db_prefix . "punchlist ADD $field TINYINT(1) NOT NULL default '0';");
-            echo "              <tr><td width=10 class=table_rows style='padding-left:25px;color:#FF9900;font-weight:bold;'>Added</td><td class=table_rows
-                      align=left>:&nbsp;<b>$field</b> field has been added to the <u>punchlist</u> table.</td></tr>\n";
-            $passed_or_not = "1";
-        }
-
-        // punchlist table changes //
-
-        $result = mysqli_query($GLOBALS["___mysqli_ston"], "SHOW FIELDS FROM " . $db_prefix . "punchlist");
-        while ($row = mysqli_fetch_array($result)) {
-            $name = "" . $row["Field"] . "";
-            $type = "" . $row["Type"] . "";
-            $tmp_type = strtoupper($type);
-
-            if (($name == 'punchitems') && ($type != 'varchar(50)')) {
-                $alter_result = mysqli_query($GLOBALS["___mysqli_ston"], "ALTER TABLE " . $db_prefix . "punchlist CHANGE punchitems punchitems VARCHAR(50) NOT NULL");
-                echo "              <tr><td width=10 class=table_rows style='padding-left:25px;color:#0000FF;font-weight:bold;'>Changed</td><td class=table_rows
-                      align=left>:&nbsp;<b>$name</b> field in <u>punchlist</u> table has been changed from type $tmp_type to type VARCHAR(50).</td></tr>\n";
-                $passed_or_not = "1";
-            }
-        }
-        ((mysqli_free_result($result) || (is_object($result) && (get_class($result) == "mysqli_result"))) ? true : false);
-
-        // add metars table //
-
-        $table = "metars";
-        $result = mysqli_query($GLOBALS["___mysqli_ston"], "SHOW TABLES LIKE '" . $db_prefix . $table . "'");
-        $rows = mysqli_num_rows($result);
-
-        if (empty($rows)) {
-            $metars_query = mysqli_query($GLOBALS["___mysqli_ston"], "CREATE TABLE " . $db_prefix . "metars (metar varchar(255) NOT NULL default '',
-                             timestamp timestamp(14) NOT NULL, station varchar(4) NOT NULL default '',
-                             PRIMARY KEY  (station), UNIQUE KEY station (station)) TYPE=MyISAM;");
-            echo "              <tr><td width=10 class=table_rows style='padding-left:25px;color:#FF9900;font-weight:bold;'>Added</td><td class=table_rows
-                      align=left>:&nbsp;<b>$table</b> table has been added to the <u>$db_name</u> database.</td></tr>\n";
-            $passed_or_not = "1";
-        }
-
-        // add dbversion table //
-
-        $table = "dbversion";
-        $result = mysqli_query($GLOBALS["___mysqli_ston"], "SHOW TABLES LIKE '" . $db_prefix . $table . "'");
-        $rows = mysqli_num_rows($result);
-
-        if (empty($rows)) {
-            $dbversion_query = mysqli_query($GLOBALS["___mysqli_ston"], "CREATE TABLE " . $db_prefix . "dbversion (dbversion decimal(5,1) NOT NULL default '0.0',
-                             PRIMARY KEY  (dbversion)) TYPE=MyISAM;");
-            echo "              <tr><td width=10 class=table_rows style='padding-left:25px;color:#FF9900;font-weight:bold;'>Added</td><td class=table_rows
-                      align=left>:&nbsp;<b>$table</b> table has been added to the <u>$db_name</u> database.</td></tr>\n";
-            $passed_or_not = "1";
-        }
-
-        // dbversion table changes //
-
-        $table = "dbversion";
-        $result = mysqli_query($GLOBALS["___mysqli_ston"], "SHOW TABLES LIKE '" . $db_prefix . $table . "'");
-        $rows = mysqli_num_rows($result);
-
-        if (!empty($rows)) {
-            $dbversion_result = mysqli_query($GLOBALS["___mysqli_ston"], "select * from " . $db_prefix . "dbversion");
-            while ($row = mysqli_fetch_array($dbversion_result)) {
-                $tmp_dbversion = "" . $row["dbversion"] . "";
-            }
-            if (!isset($tmp_dbversion)) {
-                $compare_result = mysqli_query($GLOBALS["___mysqli_ston"], "INSERT INTO " . $db_prefix . "dbversion (dbversion) VALUES ('" . $dbversion . "');");
-                echo "                  <tr><td width=10 class=table_rows style='padding-left:25px;color:#0000FF;font-weight:bold;'>Changed</td><td class=table_rows
-                          align=left>:&nbsp;the version of the database is $dbversion.</td></tr>\n";
-                $passed_or_not = "1";
-            } elseif (@$tmp_dbversion != $dbversion) {
-                $update_query = "update dbversion set " . $db_prefix . "dbversion = '" . $dbversion . "'";
-                $update_result = mysqli_query($GLOBALS["___mysqli_ston"], $update_query);
-                echo "                  <tr><td width=10 class=table_rows style='padding-left:25px;color:#0000FF;font-weight:bold;'>Changed</td><td class=table_rows
-                          align=left>:&nbsp;the version of the database has been changed from <b>$tmp_dbversion</b> to <b>$dbversion</b>.</td></tr>\n";
-                $passed_or_not = "1";
-            }
-        }
-
-        // add offices table //
-
-        $table = "offices";
-        $result = mysqli_query($GLOBALS["___mysqli_ston"], "SHOW TABLES LIKE '" . $db_prefix . $table . "'");
-        $rows = mysqli_num_rows($result);
-
-        if (empty($rows)) {
-            $metars_query = mysqli_query($GLOBALS["___mysqli_ston"], "CREATE TABLE " . $db_prefix . "offices (officename varchar(50) NOT NULL default '',
-                             officeid int(10) NOT NULL auto_increment,
-                             PRIMARY KEY  (officeid), UNIQUE KEY officeid (officeid)) TYPE=MyISAM;");
-            echo "              <tr><td width=10 class=table_rows style='padding-left:25px;color:#FF9900;font-weight:bold;'>Added</td><td class=table_rows
-                      align=left>:&nbsp;<b>$table</b> table has been added to the <u>$db_name</u> database.</td></tr>\n";
-            $passed_or_not = "1";
-        }
-
-        // add groups table //
-
-        $table = "groups";
-        $result = mysqli_query($GLOBALS["___mysqli_ston"], "SHOW TABLES LIKE '" . $db_prefix . $table . "'");
-        $rows = mysqli_num_rows($result);
-
-        if (empty($rows)) {
-            $metars_query = mysqli_query($GLOBALS["___mysqli_ston"], "CREATE TABLE " . $db_prefix . "groups (groupname varchar(50) NOT NULL default '',
-                             groupid int(10) NOT NULL auto_increment,
-                             officeid int(10) NOT NULL default '0',
-                             PRIMARY KEY  (groupid), UNIQUE KEY groupid (groupid)) TYPE=MyISAM;");
-            echo "              <tr><td width=10 class=table_rows style='padding-left:25px;color:#FF9900;font-weight:bold;'>Added</td><td class=table_rows
-                      align=left>:&nbsp;<b>$table</b> table has been added to the <u>$db_name</u> database.</td></tr>\n";
-            $passed_or_not = "1";
-        }
-
-        // add audit table //
-
-        $table = "audit";
-        $result = mysqli_query($GLOBALS["___mysqli_ston"], "SHOW TABLES LIKE '" . $db_prefix . $table . "'");
-        $rows = mysqli_num_rows($result);
-
-        if (empty($rows)) {
-            $audit_query = mysqli_query($GLOBALS["___mysqli_ston"], "CREATE TABLE " . $db_prefix . "audit (modified_by_ip varchar(39) NOT NULL default '',
-                             modified_by_user varchar(50) NOT NULL default '',
-                             modified_when bigint(14) NOT NULL, modified_from bigint(14) NOT NULL, 
-                             modified_to bigint(14) NOT NULL, modified_why varchar(250) NOT NULL default '',
-                             user_modified varchar(50) NOT NULL,
-                             PRIMARY KEY  (modified_when), UNIQUE KEY modified_when (modified_when)) TYPE=MyISAM;");
-            echo "              <tr><td width=10 class=table_rows style='padding-left:25px;color:#FF9900;font-weight:bold;'>Added</td><td class=table_rows
-                      align=left>:&nbsp;<b>$table</b> table has been added to the <u>$db_name</u> database.</td></tr>\n";
-            $passed_or_not = "1";
-        }
-
-        if (isset($recreate_admin)) {
-
-            if ($recreate_admin == '1') {
-
-                // add admin user //
-
-                $admin = "admin";
-
-                $query_admin = "select empfullname from " . $db_prefix . "employees where empfullname = '" . $admin . "'";
-                $result_admin = mysqli_query($GLOBALS["___mysqli_ston"], $query_admin);
-
-                while ($row_admin = mysqli_fetch_array($result_admin)) {
-                    $admin_user = stripslashes("" . $row_admin['empfullname'] . "");
-                }
-
-                if (!isset($admin_user)) {
-                    $add_admin_query = mysqli_query($GLOBALS["___mysqli_ston"], "INSERT INTO " . $db_prefix . "employees
-                                            VALUES ('admin', NULL, 'xy.RY2HT1QTc2', 'administrator', '', '', '', 1, 1, 1, '');");
-
-                    echo "              <tr><td width=10 class=table_rows style='padding-left:25px;color:#FF9900;font-weight:bold;'>Added</td><td class=table_rows
-                                  align=left>:&nbsp;<b>$admin</b> user has been added to the <u>$db_name</u> database.</td></tr>\n";
-                    $passed_or_not = "1";
+                tc_query("UPDATE {$db_prefix}info SET timestamp = (unix_timestamp(tstamp) - '$gmt_offset')");
+                $num_rows = mysqli_affected_rows($GLOBALS["___mysqli_ston"]);
+                if (!empty($num_rows)) {
+                    msg_converted("<b>$num_rows rows</b> in the info table were converted from a mysql timestamp to a unix timestamp.");
                 }
             }
         }
 
-        // convert mysql timestamps to unix timestamps //
+        $changes_made += ensure_field("info", "fullname",  "varchar(50)",  "COLLATE utf8_bin NOT NULL DEFAULT ''");
+        $changes_made += ensure_field("info", "inout",     "varchar(50)",  "COLLATE utf8_bin NOT NULL DEFAULT ''");
+        $changes_made += ensure_field("info", "timestamp", "bigint(14)",   "DEFAULT NULL");
+        $changes_made += ensure_field("info", "notes",     "varchar(250)", "COLLATE utf8_bin DEFAULT NULL");
+        $changes_made += ensure_field("info", "ipaddress", "varchar(39)",  "COLLATE utf8_bin NOT NULL DEFAULT ''");
 
-        if (!empty($emp_tstamp_count)) {
-            $emp_tstamp_result = mysqli_query($GLOBALS["___mysqli_ston"], "update " . $db_prefix . "employees set tstamp = (unix_timestamp(tstamp) - '" . $gmt_offset . "')");
-            $employee_rows = mysqli_affected_rows($GLOBALS["___mysqli_ston"]);
+        $changes_made += ensure_index("info", "fullname");
+        $changes_made += ensure_index("info", "timestamp");
 
-            if (!empty($employee_rows)) {
-                echo "                <tr><td width=10 class=table_rows style='padding-left:25px;color:#FF9900;font-weight:bold;'>Converted</td><td class=table_rows
-                   align=left>:&nbsp;<b>$employee_rows rows</b> in the employees table were converted from a mysql timestamp to a unix 
-                   timestamp.</td></tr>\n";
+
+        // TABLE: metars //
+        $changes_made += ensure_table("metars", "station varchar(4) PRIMARY KEY COLLATE utf8_bin");
+
+        $changes_made += ensure_field("metars", "station",   "varchar(4)",    "PRIMARY KEY COLLATE utf8_bin");
+        $changes_made += ensure_field("metars", "metar",     "varchar(255)",  "COLLATE utf8_bin NOT NULL DEFAULT ''");
+        $changes_made += ensure_field("metars", "timestamp", "timestamp",     "NOT NULL");
+
+
+        // TABLE: offices //
+        $changes_made += ensure_table("offices", "officeid int(10) AUTO_INCREMENT PRIMARY KEY");
+
+        $changes_made += ensure_field("offices", "officeid",   "int(10)",     "AUTO_INCREMENT PRIMARY KEY");
+        $changes_made += ensure_field("offices", "officename", "varchar(50)", "COLLATE utf8_bin NOT NULL DEFAULT ''");
+
+
+        // TABLE: punchlist //
+        $changes_made += ensure_table("punchlist", "punchitems varchar(50) PRIMARY KEY COLLATE utf8_bin");
+
+        $changes_made += ensure_field("punchlist", "punchitems", "varchar(50)", "PRIMARY KEY COLLATE utf8_bin");
+        $changes_made += ensure_field("punchlist", "color",      "varchar(7)",  "COLLATE utf8_bin NOT NULL DEFAULT ''");
+        $changes_made += ensure_field("punchlist", "in_or_out",  "tinyint(1)",  "DEFAULT NULL");
+
+
+        // TABLE: dbversion //
+        $changes_made += ensure_table("dbversion", "dbversion decimal(5,1) NOT NULL DEFAULT '0.0'");
+
+        $changes_made += ensure_field("dbversion", "dbversion", "decimal(5,1)", "NOT NULL DEFAULT '0.0'");
+
+        $current_dbversion = tc_select_value("dbversion", "dbversion");
+        if (empty($current_dbversion)) {
+            tc_insert_strings("dbversion", array("dbversion" => $dbversion));
+            $changes_made += 1;
+            msg_changed("the database is now at version $dbversion.");
+        }
+        elseif ($current_dbversion != $dbversion) {
+            tc_update_strings("dbversion", array("dbversion" => $dbversion));
+            msg_changed("the database has been upgraded from version <b>$current_dbversion</b> to version <b>$dbversion</b>.");
+            $changes_made += 1;
+        }
+
+        // Recreate admin //
+        if (isset($recreate_admin) and $recreate_admin == '1') {
+            $admin = "admin";
+            $admin_user = tc_select_value("empfullname", "employees", "empfullname = ?", $admin);
+
+            if (!isset($admin_user)) {
+                tc_insert_strings("employees", array(
+                    "empfullname"     => $admin,
+                    "employee_passwd" => 'xy.RY2HT1QTc2',
+                    "displayname"     => 'administrator',
+                    "admin"           => 1,
+                    "reports"         => 1,
+                    "time_admin"      => 1,
+                ));
+                msg_added("<b>$admin</b> user has been added to the <u>$db_name</u> database.");
+                $changes_made += 1;
             }
         }
-        unset($emp_tstamp_count);
 
-        if (!empty($info_timestamp_count)) {
-            $info_timestamp_result = mysqli_query($GLOBALS["___mysqli_ston"], "update " . $db_prefix . "info set timestamp = (unix_timestamp(timestamp) - '" . $gmt_offset . "')");
-            $info_rows = mysqli_affected_rows($GLOBALS["___mysqli_ston"]);
 
-            if (!empty($info_rows)) {
-                echo "                <tr><td width=10 class=table_rows style='padding-left:25px;color:purple;font-weight:bold;'>Converted</td><td class=table_rows
-                   align=left>:<b>$info_rows rows</b> in the info table were converted from a mysql timestamp to a unix timestamp.</b></td></tr>\n";
-            }
-        }
-        unset($info_timestamp_count);
-
-        if (empty($passed_or_not)) {
-            echo "              <tr><td class=table_rows style='padding-left:25px;' height=40 valign=bottom colspan=2><b>No changes were made to the
-                      database.</b></td></tr>\n";
+        if (empty($changes_made)) {
+            echo "<tr><td class=table_rows style='padding-left:25px;' height=40 valign=bottom colspan=2><b>No changes were made to the database.</b></td></tr>\n";
         } else {
-            echo "              <tr><td class=table_rows style='padding-left:25px;' height=40 valign=bottom colspan=2><b>Your database is now up to date.</b>
-                      </td></tr>\n";
+            echo "<tr><td class=table_rows style='padding-left:25px;' height=40 valign=bottom colspan=2><b>Your database is now up to date.</b></td></tr>\n";
         }
         echo "            </table>\n";
         echo "          </td>\n";

--- a/admin/dbupgrade.php
+++ b/admin/dbupgrade.php
@@ -253,6 +253,7 @@ if (!empty($count)) {
         $changes_made += ensure_field("employees", "employee_passwd",  "varchar(25)", "COLLATE utf8_bin NOT NULL DEFAULT ''");
         $changes_made += ensure_field("employees", "displayname",      "varchar(50)", "COLLATE utf8_bin NOT NULL DEFAULT ''");
         $changes_made += ensure_field("employees", "email",            "varchar(75)", "COLLATE utf8_bin NOT NULL DEFAULT ''");
+        $changes_made += ensure_field("employees", "barcode",          "varchar(75)", "COLLATE utf8_bin UNIQUE");
         $changes_made += ensure_field("employees", "groups",           "varchar(50)", "COLLATE utf8_bin NOT NULL DEFAULT ''");
         $changes_made += ensure_field("employees", "office",           "varchar(50)", "COLLATE utf8_bin NOT NULL DEFAULT ''");
         $changes_made += ensure_field("employees", "admin",            "tinyint(1)",  "NOT NULL DEFAULT '0'");
@@ -320,6 +321,7 @@ if (!empty($count)) {
         $changes_made += ensure_table("punchlist", "punchitems varchar(50) PRIMARY KEY COLLATE utf8_bin");
 
         $changes_made += ensure_field("punchlist", "punchitems", "varchar(50)", "PRIMARY KEY COLLATE utf8_bin");
+        $changes_made += ensure_field("punchlist", "punchnext",  "varchar(50)", "varchar(50) COLLATE utf8_bin NOT NULL DEFAULT ''");
         $changes_made += ensure_field("punchlist", "color",      "varchar(7)",  "COLLATE utf8_bin NOT NULL DEFAULT ''");
         $changes_made += ensure_field("punchlist", "in_or_out",  "tinyint(1)",  "DEFAULT NULL");
 

--- a/admin/statusadmin.php
+++ b/admin/statusadmin.php
@@ -72,7 +72,8 @@ echo "            </table>\n";
 echo "            <table class=table_border width=60% align=center border=0 cellpadding=0 cellspacing=0>\n";
 echo "              <tr><th class=table_heading nowrap width=7% align=left>&nbsp;</th>\n";
 echo "                <th class=table_heading nowrap width=23% align=left>Status Name</th>\n";
-echo "                <th class=table_heading nowrap width=60% align=left>Color</th>\n";
+echo "                <th class=table_heading nowrap width=23% align=left>On Punch</th>\n";
+echo "                <th class=table_heading nowrap width=37% align=left>Color</th>\n";
 echo "                <th class=table_heading nowrap width=4% align=center>In/Out</th>\n";
 echo "                <th class=table_heading nowrap width=3% align=center>Edit</th>\n";
 echo "                <th class=table_heading nowrap width=3% align=center>Delete</th></tr>\n";
@@ -84,6 +85,7 @@ $result = tc_select("*", "punchlist");
 while ($row = mysqli_fetch_array($result)) {
 
     $punchitem = "" . $row['punchitems'] . "";
+    $punchnext = "" . $row['punchnext'] . "";
     $color = "" . $row['color'] . "";
     $in_or_out = "" . $row['in_or_out'] . "";
 
@@ -99,7 +101,9 @@ while ($row = mysqli_fetch_array($result)) {
     echo "              <tr class=table_border bgcolor='$row_color'><td nowrap class=table_rows width=7%>&nbsp;$row_count</td>\n";
     echo "                <td nowrap class=table_rows width=23%>&nbsp;<a class=footer_links title='Edit Status: $punchitem'
                     href='statusedit.php?statusname=$punchitem'>$punchitem</a></td>\n";
-    echo "                <td class=table_rows width=60% align=left style='color:$color';>&nbsp;$color</td>\n";
+    echo "                <td nowrap class=table_rows width=23%>&nbsp;" . ($punchnext ? "&rarr;&nbsp;" : "") . "<a class=footer_links title='Edit Status: $punchnext'
+                    href='statusedit.php?statusname=$punchnext'>$punchnext</a></td>\n";
+    echo "                <td class=table_rows width=37% align=left style='color:$color';>&nbsp;$color</td>\n";
     echo "                <td nowrap class=table_rows width=4% align=center>$in_or_out_tmp</td>\n";
 
     if ((strpos($user_agent, "MSIE 6")) || (strpos($user_agent, "MSIE 5")) || (strpos($user_agent, "MSIE 4")) || (strpos($user_agent, "MSIE 3"))) {

--- a/admin/statusadmin.php
+++ b/admin/statusadmin.php
@@ -79,8 +79,7 @@ echo "                <th class=table_heading nowrap width=3% align=center>Delet
 
 $row_count = 0;
 
-$query = "select * from " . $db_prefix . "punchlist";
-$result = mysqli_query($GLOBALS["___mysqli_ston"], $query);
+$result = tc_select("*", "punchlist");
 
 while ($row = mysqli_fetch_array($result)) {
 

--- a/admin/statuscreate.php
+++ b/admin/statuscreate.php
@@ -153,16 +153,11 @@ if ($request == 'GET') {
         exit;
     }
 
-    $post_statusname = stripslashes($post_statusname);
-    $post_statusname = addslashes($post_statusname);
-
-    $string = strstr($post_statusname, "\'");
+    $string  = strstr($post_statusname, "'");
     $string2 = strstr($post_statusname, "\"");
 
     if (empty($string)) {
-        $query = "select punchitems from " . $db_prefix . "punchlist where punchitems = '" . $post_statusname . "'";
-        $result = mysqli_query($GLOBALS["___mysqli_ston"], $query);
-
+        $result = tc_select("punchitems", "punchlist", "punchitems = ?", $post_statusname);
         while ($row = mysqli_fetch_array($result)) {
             $dupe = '1';
         }
@@ -213,13 +208,6 @@ if ($request == 'GET') {
             echo "            </table>\n";
         }
 
-        if (!empty($string)) {
-            $post_statusname = stripslashes($post_statusname);
-        }
-        if (!empty($string2)) {
-            $post_statusname = stripslashes($post_statusname);
-        }
-
         echo "            <br />\n";
         echo "            <form name='form' action='$self' method='post'>\n";
         echo "            <table align=center class=table_border width=60% border=0 cellpadding=3 cellspacing=0>\n";
@@ -244,13 +232,6 @@ if ($request == 'GET') {
                       <input checked type='radio' name='create_status' value='0'>Out</td></tr>\n";
         }
 
-        if (!empty($string)) {
-            $post_statusname = stripslashes($post_statusname);
-        }
-        if (!empty($string2)) {
-            $post_statusname = stripslashes($post_statusname);
-        }
-
         echo "              <tr><td class=table_rows align=right colspan=3 style='color:red;font-family:Tahoma;font-size:10px;'>*&nbsp;required&nbsp;</td></tr>\n";
         echo "            </table>\n";
         echo "            <script language=\"javascript\">cp.writeDiv()</script>\n";
@@ -264,9 +245,7 @@ if ($request == 'GET') {
         exit;
 
     } else {
-
-        $query = "insert into " . $db_prefix . "punchlist (punchitems, color, in_or_out) values ('" . $post_statusname . "', '" . $post_color . "', '" . $create_status . "')";
-        $result = mysqli_query($GLOBALS["___mysqli_ston"], $query);
+        $result = tc_insert_strings("punchlist", array("punchitems" => $post_statusname, "color" => $post_color, "in_or_out" => $create_status));
 
         echo "            <table align=center class=table_border width=60% border=0 cellpadding=0 cellspacing=3>\n";
         echo "              <tr>\n";

--- a/admin/statusdelete.php
+++ b/admin/statusdelete.php
@@ -40,8 +40,7 @@ if ($request == 'GET') {
 
     $get_status = $_GET['statusname'];
 
-    $query = "select * from " . $db_prefix . "punchlist where punchitems = '" . $get_status . "'";
-    $result = mysqli_query($GLOBALS["___mysqli_ston"], $query);
+    $result = tc_select("*", "punchlist", "punchitems = ?", $get_status);
 
     while ($row = mysqli_fetch_array($result)) {
 
@@ -124,7 +123,7 @@ if ($request == 'GET') {
     echo "            </table>\n";
     echo "            <table align=center width=60% border=0 cellpadding=0 cellspacing=3>\n";
     echo "              <tr><td class=table_rows height=53 align=left colspan=2 style='color:red;font-size:10px;'>
-                      Deleting this status does NOT delete it from the database history. It merely removes it from the list of status 
+                      Deleting this status does NOT delete it from the database history. It merely removes it from the list of status
                       choices.</td></tr></table>\n";
     echo "            <table align=center width=60% border=0 cellpadding=0 cellspacing=3>\n";
     echo "              <tr><td width=30><input type='image' name='submit' value='Delete Status' src='../images/buttons/next_button.png'></td>
@@ -145,11 +144,9 @@ if ($request == 'GET') {
         exit;
     }
 
-    $query = "select * from " . $db_prefix . "punchlist where punchitems = '" . $post_statusname . "'";
-    $result = mysqli_query($GLOBALS["___mysqli_ston"], $query);
+    $result = tc_select("*", "punchlist", "punchitems = ?", $post_statusname);
 
     while ($row = mysqli_fetch_array($result)) {
-
         $punchitem = "" . $row['punchitems'] . "";
         $color = "" . $row['color'] . "";
         $in_or_out = "" . $row['in_or_out'] . "";
@@ -159,8 +156,7 @@ if ($request == 'GET') {
         exit;
     }
 
-    $query2 = "delete from " . $db_prefix . "punchlist where punchitems = ('" . $post_statusname . "')";
-    $result2 = mysqli_query($GLOBALS["___mysqli_ston"], $query2);
+    $result2 = tc_delete("punchlist", "punchitems = ?", $post_statusname);
 
     if ($post_in_out == '1') {
         $post_in_out = 'In';
@@ -232,7 +228,7 @@ if ($request == 'GET') {
     echo "              </tr>\n";
     echo "              <tr><td height=15></td></tr>\n";
     echo "              <tr><td class=table_rows height=25 width=20% style='padding-left:32px;' nowrap>Status Name:</td><td align=left width=80%
-                      style='padding-left:20px;' class=table_rows><input type='hidden' name='post_statusname' 
+                      style='padding-left:20px;' class=table_rows><input type='hidden' name='post_statusname'
                       value=\"$post_statusname\">$post_statusname</td></tr>\n";
     echo "              <tr><td class=table_rows height=25 width=20% style='padding-left:32px;' nowrap>Color:</td><td align=left class=table_rows
                       width=80% style='padding-left:20px;'><input type='hidden' name='post_color' value=\"$post_color\">$post_color</td></tr>\n";

--- a/admin/statusedit.php
+++ b/admin/statusedit.php
@@ -40,11 +40,9 @@ if ($request == 'GET') {
 
     $get_status = $_GET['statusname'];
 
-    $query = "select * from " . $db_prefix . "punchlist where punchitems = '" . $get_status . "'";
-    $result = mysqli_query($GLOBALS["___mysqli_ston"], $query);
+    $result = tc_select("*", "punchlist", "punchitems = ?", $get_status);
 
     while ($row = mysqli_fetch_array($result)) {
-
         $punchitem = "" . $row['punchitems'] . "";
         $color = "" . $row['color'] . "";
         $in_or_out = "" . $row['in_or_out'] . "";
@@ -147,12 +145,7 @@ if ($request == 'GET') {
     // begin post validation //
 
     if (!empty($get_status)) {
-        $query = "select * from " . $db_prefix . "punchlist where punchitems = '" . $get_status . "'";
-        $result = mysqli_query($GLOBALS["___mysqli_ston"], $query);
-        while ($row = mysqli_fetch_array($result)) {
-            $getstatus = "" . $row['punchitems'] . "";
-        }
-        ((mysqli_free_result($result) || (is_object($result) && (get_class($result) == "mysqli_result"))) ? true : false);
+        $getstatus = tc_select_value("punchitems", "punchlist", "punchitems = ?", $get_status);
         if (!isset($getstatus)) {
             echo "Status is not defined.\n";
             exit;
@@ -163,12 +156,7 @@ if ($request == 'GET') {
         exit;
     }
 
-    if (get_magic_quotes_gpc()) {
-        $post_statusname = stripslashes($post_statusname);
-    }
-    $post_statusname = addslashes($post_statusname);
-
-    $string = strstr($post_statusname, "\'");
+    $string  = strstr($post_statusname, "'");
     $string2 = strstr($post_statusname, "\"");
 
     if ((empty($post_statusname)) || (empty($post_color)) || (!preg_match('/' . "^([[:alnum:]]| |-|_|.)+$" . '/i', $post_statusname)) ||
@@ -260,13 +248,6 @@ if ($request == 'GET') {
             echo "            </table>\n";
         }
 
-        if (!empty($string)) {
-            $post_statusname = stripslashes($post_statusname);
-        }
-        if (!empty($string2)) {
-            $post_statusname = stripslashes($post_statusname);
-        }
-
         echo "            <br />\n";
         echo "            <table align=center class=table_border width=60% border=0 cellpadding=3 cellspacing=0>\n";
         echo "            <form name='form' action='$self' method='post'>\n";
@@ -295,13 +276,6 @@ if ($request == 'GET') {
             exit;
         }
 
-        if (!empty($string)) {
-            $post_statusname = stripslashes($post_statusname);
-        }
-        if (!empty($string2)) {
-            $post_statusname = stripslashes($post_statusname);
-        }
-
         echo "              <tr><td class=table_rows align=right colspan=3 style='color:red;font-family:Tahoma;font-size:10px;'>*&nbsp;required&nbsp;</td></tr>\n";
         echo "            </table>\n";
         echo "            <script language=\"javascript\">cp.writeDiv()</script>\n";
@@ -317,12 +291,21 @@ if ($request == 'GET') {
 
     } else {
 
-        $query = "update " . $db_prefix . "punchlist set punchitems = ('" . $post_statusname . "'), color = ('" . $post_color . "'), in_or_out = ('" . $create_status . "')
-          where punchitems  = ('" . $get_status . "')";
-        $result = mysqli_query($GLOBALS["___mysqli_ston"], $query);
+        tc_update_strings(
+            "punchlist",
+            array(
+                "punchitems" => $post_statusname,
+                "color"      => $post_color,
+                "in_or_out"  => $create_status
+            ),
+            "punchitems = ?", $get_status
+        );
 
-        $query2 = "update " . $db_prefix . "info set `inout` = ('" . $post_statusname . "') where `inout` = ('" . $get_status . "')";
-        $result2 = mysqli_query($GLOBALS["___mysqli_ston"], $query2);
+        tc_update_strings(
+            "info",
+            array("inout" => $post_statusname),
+            "`inout` = ?", $get_status
+        );
 
         echo "<table width=100% height=89% border=0 cellpadding=0 cellspacing=1>\n";
         echo "  <tr valign=top>\n";

--- a/admin/statusedit.php
+++ b/admin/statusedit.php
@@ -46,6 +46,7 @@ if ($request == 'GET') {
         $punchitem = "" . $row['punchitems'] . "";
         $color = "" . $row['color'] . "";
         $in_or_out = "" . $row['in_or_out'] . "";
+        $punchnext = "" . $row['punchnext'] . "";
     }
 
     echo "<table width=100% height=89% border=0 cellpadding=0 cellspacing=1>\n";
@@ -123,6 +124,10 @@ if ($request == 'GET') {
         exit;
     }
 
+    echo "              <tr><td class=table_rows height=25 width=20% style='padding-left:32px;' nowrap>On Punch Become:</td><td colspan=2 width=80%
+                      style='color:red;font-family:Tahoma;font-size:10px;padding-left:20px;'><select name='punchnext'>\n";
+    echo "            <option value =''>...</option>" . html_options(tc_select("punchitems",  "punchlist"), $punchnext) . "</select></td></tr>\n";
+
     echo "              <tr><td class=table_rows align=right colspan=3 style='color:red;font-family:Tahoma;font-size:10px;'>*&nbsp;required&nbsp;</td></tr>\n";
     echo "            </table>\n";
     echo "            <script language=\"javascript\">cp.writeDiv()</script>\n";
@@ -141,6 +146,7 @@ if ($request == 'GET') {
     $post_statusname = $_POST['post_statusname'];
     $post_color = $_POST['post_color'];
     $create_status = $_POST['create_status'];
+    $punchnext = $_POST['punchnext'];
 
     // begin post validation //
 
@@ -152,6 +158,12 @@ if ($request == 'GET') {
         }
     }
 
+    $punchnext_ok = true;
+    if (has_value($punchnext)) {
+        $punchnext_ok = ($punchnext == tc_select_value("punchitems", "punchlist", "punchitems = ?", $punchnext));
+    }
+
+
     if (($create_status !== '0') && ($create_status !== '1')) {
         exit;
     }
@@ -161,6 +173,7 @@ if ($request == 'GET') {
 
     if ((empty($post_statusname)) || (empty($post_color)) || (!preg_match('/' . "^([[:alnum:]]| |-|_|.)+$" . '/i', $post_statusname)) ||
         ((!preg_match('/' . "^(#[a-fA-F0-9]{6})+$" . '/i', $post_color)) && (!preg_match('/' . "^([a-fA-F0-9]{6})+$" . '/i', $post_color))) || (!empty($string)) || (!empty($string2))
+        || !$punchnext_ok
     ) {
 
         echo "<table width=100% height=89% border=0 cellpadding=0 cellspacing=1>\n";
@@ -246,6 +259,11 @@ if ($request == 'GET') {
             echo "              <tr><td class=table_rows width=20 align=center><img src='../images/icons/cancel.png' /></td><td class=table_rows_red>
                     Double Quotes are not allowed.</td></tr>\n";
             echo "            </table>\n";
+        } elseif (!$punchnext_ok) {
+            echo "            <table align=center class=table_border width=60% border=0 cellpadding=0 cellspacing=3>\n";
+            echo "              <tr><td class=table_rows width=20 align=center><img src='../images/icons/cancel.png' /></td><td class=table_rows_red>
+                    \"On Punch\" target is invalid!</td></tr>\n";
+            echo "            </table>\n";
         }
 
         echo "            <br />\n";
@@ -276,6 +294,10 @@ if ($request == 'GET') {
             exit;
         }
 
+        echo "              <tr><td class=table_rows height=25 width=20% style='padding-left:32px;' nowrap>On Punch Become:</td><td colspan=2 width=80%
+                          style='color:red;font-family:Tahoma;font-size:10px;padding-left:20px;'><select name='punchnext'>\n";
+        echo "            <option value =''>...</option>" . html_options(tc_select("punchitems",  "punchlist"), $punchnext) . "</select></td></tr>\n";
+
         echo "              <tr><td class=table_rows align=right colspan=3 style='color:red;font-family:Tahoma;font-size:10px;'>*&nbsp;required&nbsp;</td></tr>\n";
         echo "            </table>\n";
         echo "            <script language=\"javascript\">cp.writeDiv()</script>\n";
@@ -296,16 +318,19 @@ if ($request == 'GET') {
             array(
                 "punchitems" => $post_statusname,
                 "color"      => $post_color,
-                "in_or_out"  => $create_status
+                "in_or_out"  => $create_status,
+                "punchnext"  => $punchnext
             ),
             "punchitems = ?", $get_status
         );
 
-        tc_update_strings(
-            "info",
-            array("inout" => $post_statusname),
-            "`inout` = ?", $get_status
-        );
+        if ($post_statusname != $get_status) {
+            tc_update_strings(
+                "info",
+                array("inout" => $post_statusname),
+                "`inout` = ?", $get_status
+            );
+        }
 
         echo "<table width=100% height=89% border=0 cellpadding=0 cellspacing=1>\n";
         echo "  <tr valign=top>\n";
@@ -380,6 +405,8 @@ if ($request == 'GET') {
 
         echo "              <tr><td class=table_rows height=25 width=20% style='padding-left:32px;' nowrap>Is Status considered '<b>In</b>' or
                       '<b>Out</b>'?</td><td align=left class=table_rows colspan=2 width=80% style='padding-left:20px;'>$create_status_tmp</td></tr>\n";
+        echo "              <tr><td class=table_rows height=25 width=20% style='padding-left:32px;' nowrap>On Punch:</td><td align=left class=table_rows
+                      colspan=2 width=80% style='padding-left:20px;'>$punchnext</td></tr>\n";
         echo "              <tr><td height=15></td></tr>\n";
         echo "            </table>\n";
         echo "            <table align=center width=60% border=0 cellpadding=0 cellspacing=3>\n";

--- a/admin/userdelete.php
+++ b/admin/userdelete.php
@@ -38,7 +38,7 @@ if ($request == 'GET') {
         exit;
     }
 
-    $get_user = stripslashes($_GET['username']);
+    $get_user = $_GET['username'];
     @$get_office = $_GET['officename'];
 
     echo "<table width=100% height=89% border=0 cellpadding=0 cellspacing=1>\n";
@@ -91,17 +91,12 @@ if ($request == 'GET') {
     echo "        <tr class=right_main_text>\n";
     echo "          <td valign=top>\n";
 
-    $get_user = addslashes($get_user);
-
-    $row_count = 0;
-
-    $query = "select * from " . $db_prefix . "employees where empfullname = '" . $get_user . "' order by empfullname";
-    $result = mysqli_query($GLOBALS["___mysqli_ston"], $query);
+    $result = tc_select("*", "employees", "empfullname = ? ORDER BY empfullname", $get_user);
 
     while ($row = mysqli_fetch_array($result)) {
 
-        $username = stripslashes("" . $row['empfullname'] . "");
-        $displayname = stripslashes("" . $row['displayname'] . "");
+        $username = "" . $row['empfullname'] . "";
+        $displayname = "" . $row['displayname'] . "";
         $user_email = "" . $row['email'] . "";
         $office = "" . $row['office'] . "";
         $groups = "" . $row['groups'] . "";
@@ -110,13 +105,11 @@ if ($request == 'GET') {
         $time_admin = "" . $row['time_admin'] . "";
     }
     ((mysqli_free_result($result) || (is_object($result) && (get_class($result) == "mysqli_result"))) ? true : false);
-    $get_user = stripslashes($get_user);
 
     // make sure you cannot delete the last admin user in the system!! //
 
     if (!empty($admin)) {
-        $admin_count = mysqli_query($GLOBALS["___mysqli_ston"], "select empfullname from " . $db_prefix . "employees where admin = '1'");
-        @$admin_count_rows = mysqli_num_rows($admin_count);
+        @$admin_count_rows = mysqli_num_rows(tc_select("empfullname", "employees", "admin = '1'"));
         if (@$admin_count_rows == "1") {
             $evil = "1";
         }
@@ -192,8 +185,8 @@ if ($request == 'GET') {
     exit;
 } elseif ($request == 'POST') {
 
-    $post_username = stripslashes($_POST['post_username']);
-    $display_name = stripslashes($_POST['display_name']);
+    $post_username = $_POST['post_username'];
+    $display_name = $_POST['display_name'];
     $email_addy = $_POST['email_addy'];
     $office_name = $_POST['office_name'];
     $group_name = $_POST['group_name'];
@@ -202,69 +195,41 @@ if ($request == 'GET') {
     $time_admin_perms = $_POST['time_admin_perms'];
     @$delete_data = $_POST['delete_all_user_data'];
 
-    $post_username = addslashes($post_username);
-    $display_name = addslashes($display_name);
-
     // begin post validation //
 
-    if (!empty($post_username)) {
-        $query = "select * from " . $db_prefix . "employees where empfullname = '" . $post_username . "'";
-        $result = mysqli_query($GLOBALS["___mysqli_ston"], $query);
-        while ($row = mysqli_fetch_array($result)) {
-            $tmp_username = "" . $row['empfullname'] . "";
-        }
-        if (!isset($tmp_username)) {
-            echo "Something is fishy here.\n";
-            exit;
-        }
+    if (!empty($post_username)
+         and is_null(tc_select_value("empfullname", "employees", "empfullname = ?", $post_username))
+    ) {
+        echo "Something is fishy here.\n";
+        exit;
     }
 
-    if (!empty($display_name)) {
-        $query = "select * from " . $db_prefix . "employees where empfullname = '" . $post_username . "' and displayname = '" . $display_name . "'";
-        $result = mysqli_query($GLOBALS["___mysqli_ston"], $query);
-        while ($row = mysqli_fetch_array($result)) {
-            $tmp_display_name = "" . $row['displayname'] . "";
-        }
-        if (!isset($tmp_display_name)) {
-            echo "Something is fishy here.\n";
-            exit;
-        }
+    if (!empty($display_name)
+         and is_null(tc_select_value("displayname", "employees", "empfullname = ? AND displayname = ?", array($post_username, $display_name)))
+    ) {
+        echo "Something is fishy here.\n";
+        exit;
     }
 
-    if (!empty($email_addy)) {
-        $query = "select * from " . $db_prefix . "employees where empfullname = '" . $post_username . "' and email = '" . $email_addy . "'";
-        $result = mysqli_query($GLOBALS["___mysqli_ston"], $query);
-        while ($row = mysqli_fetch_array($result)) {
-            $tmp_email_addy = "" . $row['email'] . "";
-        }
-        if (!isset($tmp_email_addy)) {
-            echo "Something is fishy here.\n";
-            exit;
-        }
+    if (!empty($email_addy)
+         and is_null(tc_select_value("email", "employees", "empfullname = ? AND email = ?", array($post_username, $email_addy)))
+    ) {
+        echo "Something is fishy here.\n";
+        exit;
     }
 
-    if (!empty($office_name)) {
-        $query = "select * from " . $db_prefix . "employees where empfullname = '" . $post_username . "' and office = '" . $office_name . "'";
-        $result = mysqli_query($GLOBALS["___mysqli_ston"], $query);
-        while ($row = mysqli_fetch_array($result)) {
-            $tmp_office_name = "" . $row['office'] . "";
-        }
-        if (!isset($tmp_office_name)) {
-            echo "Something is fishy here.\n";
-            exit;
-        }
+    if (!empty($office_name)
+         and is_null(tc_select_value("office", "employees", "empfullname = ? AND office = ?", array($post_username, $office_name)))
+    ) {
+        echo "Something is fishy here.\n";
+        exit;
     }
 
-    if (!empty($group_name)) {
-        $query = "select * from " . $db_prefix . "employees where empfullname = '" . $post_username . "' and groups = '" . $group_name . "'";
-        $result = mysqli_query($GLOBALS["___mysqli_ston"], $query);
-        while ($row = mysqli_fetch_array($result)) {
-            $tmp_group_name = "" . $row['groups'] . "";
-        }
-        if (!isset($tmp_group_name)) {
-            echo "Something is fishy here.\n";
-            exit;
-        }
+    if (!empty($group_name)
+         and is_null(tc_select_value("groups", "employees", "empfullname = ? AND groups = ?", array($post_username, $group_name)))
+    ) {
+        echo "Something is fishy here.\n";
+        exit;
     }
 
     if (($admin_perms != '0') && ($admin_perms != '1')) {
@@ -286,16 +251,11 @@ if ($request == 'GET') {
 
     // end post validation //
 
-    $query2 = "delete from " . $db_prefix . "employees where empfullname = ('" . $post_username . "')";
-    $result2 = mysqli_query($GLOBALS["___mysqli_ston"], $query2);
+    tc_delete("employees", "empfullname = ?", $post_username);
 
     if ($delete_data == "1") {
-        $query3 = "delete from " . $db_prefix . "info where fullname = ('" . $post_username . "')";
-        $result3 = mysqli_query($GLOBALS["___mysqli_ston"], $query3);
+        tc_delete("info", "fullname = ?", $post_username);
     }
-
-    $post_username = stripslashes($post_username);
-    $display_name = stripslashes($display_name);
 
     echo "<table width=100% height=89% border=0 cellpadding=0 cellspacing=1>\n";
     echo "  <tr valign=top>\n";

--- a/admin/userdelete.php
+++ b/admin/userdelete.php
@@ -98,6 +98,7 @@ if ($request == 'GET') {
         $username = "" . $row['empfullname'] . "";
         $displayname = "" . $row['displayname'] . "";
         $user_email = "" . $row['email'] . "";
+        $user_barcode = "" . $row['barcode'] . "";
         $office = "" . $row['office'] . "";
         $groups = "" . $row['groups'] . "";
         $admin = "" . $row['admin'] . "";
@@ -136,6 +137,8 @@ if ($request == 'GET') {
                       width=80% style='padding-left:20px;'><input type='hidden' name='display_name' value=\"$displayname\">$displayname</td></tr>\n";
     echo "              <tr><td class=table_rows height=25 width=20% style='padding-left:32px;' nowrap>Email Address:</td><td align=left class=table_rows
                       width=80% style='padding-left:20px;'><input type='hidden' name='email_addy' value=\"$user_email\">$user_email</td></tr>\n";
+    echo "              <tr><td class=table_rows height=25 width=20% style='padding-left:32px;' nowrap>Barcode:</td><td align=left class=table_rows
+                      width=80% style='padding-left:20px;'><input type='hidden' name='barcode' value=\"$user_barcode\">$user_barcode</td></tr>\n";
     echo "              <tr><td class=table_rows height=25 width=20% style='padding-left:32px;' nowrap>Office:</td><td align=left class=table_rows
                       width=80% style='padding-left:20px;'><input type='hidden' name='office_name' value=\"$office\">$office</td></tr>\n";
     echo "              <tr><td class=table_rows height=25 width=20% style='padding-left:32px;' nowrap>Group:</td><td align=left class=table_rows
@@ -188,6 +191,7 @@ if ($request == 'GET') {
     $post_username = $_POST['post_username'];
     $display_name = $_POST['display_name'];
     $email_addy = $_POST['email_addy'];
+    $user_barcode = $_POST['barcode'];
     $office_name = $_POST['office_name'];
     $group_name = $_POST['group_name'];
     $admin_perms = $_POST['admin_perms'];

--- a/admin/useredit.php
+++ b/admin/useredit.php
@@ -103,6 +103,7 @@ if ($request == 'GET') {
         $username = "" . $row['empfullname'] . "";
         $displayname = "" . $row['displayname'] . "";
         $user_email = "" . $row['email'] . "";
+        $user_barcode = "" . $row['barcode'] . "";
         $groups_tmp = "" . $row['groups'] . "";
         $office = "" . $row['office'] . "";
         $admin = "" . $row['admin'] . "";
@@ -144,6 +145,9 @@ if ($request == 'GET') {
     echo "              <tr><td class=table_rows height=25 width=20% style='padding-left:32px;' nowrap>Email Address:</td><td colspan=2 width=80%
                       style='color:red;font-family:Tahoma;font-size:10px;padding-left:20px;'>
                       <input type='text' size='25' maxlength='75' name='email_addy' value='$user_email'>&nbsp;*</td></tr>\n";
+    echo "              <tr><td class=table_rows height=25 width=20% style='padding-left:32px;' nowrap>Barcode:</td><td colspan=2 width=80%
+                      style='color:red;font-family:Tahoma;font-size:10px;padding-left:20px;'>
+                      <input type='text' size='25' maxlength='75' name='barcode' value='$user_barcode'></td></tr>\n";
     echo "              <tr><td class=table_rows height=25 width=20% style='padding-left:32px;' nowrap>Office:</td><td colspan=2 width=80%
                       style='color:red;font-family:Tahoma;font-size:10px;padding-left:20px;'>
                       <select name='office_name' onchange='group_names();'>
@@ -225,6 +229,7 @@ if ($request == 'GET') {
     $post_username = $_POST['post_username'];
     $display_name = $_POST['display_name'];
     $email_addy = $_POST['email_addy'];
+    $user_barcode = value_or_null($_POST['barcode']);// UNIQUE constraint so no empty strings
     $office_name = $_POST['office_name'];
     @$get_office = $_POST['get_office'];
     @$group_name = $_POST['group_name'];
@@ -417,6 +422,9 @@ if ($request == 'GET') {
         echo "              <tr><td class=table_rows height=25 width=20% style='padding-left:32px;' nowrap>Email Address:</td><td colspan=2 width=80%
                       style='color:red;font-family:Tahoma;font-size:10px;padding-left:20px;'>
                       <input type='text' size='25' maxlength='75' name='email_addy' value='$email_addy'>&nbsp;*</td></tr>\n";
+        echo "              <tr><td class=table_rows height=25 width=20% style='padding-left:32px;' nowrap>Barcode:</td><td colspan=2 width=80%
+                      style='color:red;font-family:Tahoma;font-size:10px;padding-left:20px;'>
+                      <input type='text' size='25' maxlength='75' name='barcode' value='$user_barcode'></td></tr>\n";
         echo "              <tr><td class=table_rows height=25 width=20% style='padding-left:32px;' nowrap>Office:</td><td colspan=2 width=80%
                       style='color:red;font-family:Tahoma;font-size:10px;padding-left:20px;'>
                       <select name='office_name' onchange='group_names();'>\n";
@@ -480,6 +488,7 @@ if ($request == 'GET') {
     tc_update_strings("employees", array(
         'displayname' => $display_name,
         'email'       => $email_addy,
+        'barcode'     => $user_barcode,
         'groups'      => $group_name,
         'office'      => $office_name,
         'admin'       => $admin_perms,
@@ -552,7 +561,7 @@ if ($request == 'GET') {
     echo "              <tr><td height=15></td></tr>\n";
 
     $result4 = tc_select(
-        "empfullname, displayname, email, groups, office, admin, reports, time_admin, disabled",
+        "empfullname, displayname, email, barcode, groups, office, admin, reports, time_admin, disabled",
         "employees",
         "empfullname = ? ORDER BY empfullname",
         $post_username
@@ -561,6 +570,7 @@ if ($request == 'GET') {
         $username = "" . $row['empfullname'] . "";
         $displayname = "" . $row['displayname'] . "";
         $user_email = "" . $row['email'] . "";
+        $user_barcode = "" . $row['barcode'] . "";
         $office = "" . $row['office'] . "";
         $groups = "" . $row['groups'] . "";
         $admin = "" . $row['admin'] . "";
@@ -576,6 +586,8 @@ if ($request == 'GET') {
                       colspan=2 width=80% style='padding-left:20px;'>$displayname</td></tr>\n";
     echo "              <tr><td class=table_rows height=25 width=20% style='padding-left:32px;' nowrap>Email Address:</td><td align=left class=table_rows
                       colspan=2 width=80% style='padding-left:20px;'>$user_email</td></tr>\n";
+    echo "              <tr><td class=table_rows height=25 width=20% style='padding-left:32px;' nowrap>Barcode:</td><td align=left class=table_rows
+                      colspan=2 width=80% style='padding-left:20px;'>$user_barcode</td></tr>\n";
     echo "              <tr><td class=table_rows height=25 width=20% style='padding-left:32px;' nowrap>Office:</td><td align=left class=table_rows
                       colspan=2 width=80% style='padding-left:20px;'>$office</td></tr>\n";
     echo "              <tr><td class=table_rows height=25 width=20% style='padding-left:32px;' nowrap>Group:</td><td align=left class=table_rows

--- a/admin/useredit.php
+++ b/admin/useredit.php
@@ -43,10 +43,6 @@ if ($request == 'GET') {
     $get_user = $_GET['username'];
     @$get_office = $_GET['officename'];
 
-    if (get_magic_quotes_gpc()) {
-        $get_user = stripslashes($get_user);
-    }
-
     echo "<table width=100% height=89% border=0 cellpadding=0 cellspacing=1>\n";
     echo "  <tr valign=top>\n";
     echo "    <td class=left_main width=180 align=left scope=col>\n";
@@ -97,20 +93,15 @@ if ($request == 'GET') {
     echo "        <tr class=right_main_text>\n";
     echo "          <td valign=top>\n";
 
-    $get_user = addslashes($get_user);
-
     $row_count = 0;
-
-    $query = "select * from " . $db_prefix . "employees where empfullname = '" . $get_user . "' order by empfullname";
-    $result = mysqli_query($GLOBALS["___mysqli_ston"], $query);
+    $result = tc_select("*", "employees", "empfullname = ?", $get_user);
 
     while ($row = mysqli_fetch_array($result)) {
-
         $row_count++;
         $row_color = ($row_count % 2) ? $color2 : $color1;
 
-        $username = stripslashes("" . $row['empfullname'] . "");
-        $displayname = stripslashes("" . $row['displayname'] . "");
+        $username = "" . $row['empfullname'] . "";
+        $displayname = "" . $row['displayname'] . "";
         $user_email = "" . $row['email'] . "";
         $groups_tmp = "" . $row['groups'] . "";
         $office = "" . $row['office'] . "";
@@ -124,8 +115,7 @@ if ($request == 'GET') {
     // make sure you cannot edit the admin perms for the last admin user in the system!! //
 
     if (!empty($admin)) {
-        $admin_count = mysqli_query($GLOBALS["___mysqli_ston"], "select empfullname from " . $db_prefix . "employees where admin = '1'");
-        @$admin_count_rows = mysqli_num_rows($admin_count);
+        @$admin_count_rows = mysqli_num_rows(tc_select("empfullname", "employees", "admin = '1'"));
         if (@$admin_count_rows == "1") {
             $evil = "1";
         }
@@ -223,7 +213,7 @@ if ($request == 'GET') {
     echo "              <tr><td height=40>&nbsp;</td></tr>\n";
     echo "                  <input type='hidden' name='get_office' value='$get_office'>\n";
     echo "              <tr><td width=30><input type='image' name='submit' value='Edit User' align='middle'
-                      src='../images/buttons/next_button.png'></td><td><a href='useradmin.php'><img src='../images/buttons/cancel_button.png' 
+                      src='../images/buttons/next_button.png'></td><td><a href='useradmin.php'><img src='../images/buttons/cancel_button.png'
                       border='0'></td></tr></table></form></td></tr>\n";
     include '../footer.php';
     exit;
@@ -232,8 +222,8 @@ if ($request == 'GET') {
     include 'header_post.php';
     include 'topmain.php';
 
-    $post_username = stripslashes($_POST['post_username']);
-    $display_name = stripslashes($_POST['display_name']);
+    $post_username = $_POST['post_username'];
+    $display_name = $_POST['display_name'];
     $email_addy = $_POST['email_addy'];
     $office_name = $_POST['office_name'];
     @$get_office = $_POST['get_office'];
@@ -254,22 +244,18 @@ if ($request == 'GET') {
     if (isset($evil)) {
         $admin_perms = "1";
     }
-    $post_username = addslashes($post_username);
 
     if (!empty($post_username)) {
-        $query = "select * from " . $db_prefix . "employees where empfullname = '" . $post_username . "'";
-        $result = mysqli_query($GLOBALS["___mysqli_ston"], $query);
-        while ($row = mysqli_fetch_array($result)) {
-            $tmp_username = "" . $row['empfullname'] . "";
-        }
+        $tmp_username = tc_select_value("empfullname", "employees", "empfullname = ?", $post_username);
         if (!isset($tmp_username)) {
-            echo "$tmp_username, $post_username. Something is fishy here.\n";
+            echo htmlspecialchars("$tmp_username, $post_username. Something is fishy here.\n");
             exit;
         }
     }
+    else {
+        $tmp_username = "";
+    }
 
-    $post_username = stripslashes($post_username);
-    $tmp_post_username = stripslashes($post_username);
     $string = strstr($display_name, "\"");
     if ((!preg_match('/' . "^([[:alnum:]]| |-|'|,)+$" . '/i', $display_name)) || (empty($display_name)) || (empty($email_addy)) || (empty($office_name)) || (empty($group_name)) ||
         (!preg_match('/' . "^([[:alnum:]]|_|\.|-)+@([[:alnum:]]|\.|-)+(\.)([a-z]{2,4})$" . '/i', $email_addy)) || (($admin_perms != '1') && (!empty($admin_perms))) ||
@@ -286,12 +272,12 @@ if ($request == 'GET') {
         echo "        <tr><td class=left_rows height=18 align=left valign=middle><img src='../images/icons/user.png' alt='User Summary' />&nbsp;&nbsp;
                 <a class=admin_headings href='useradmin.php'>User Summary</a></td></tr>\n";
         echo "        <tr><td class=current_left_rows_indent height=18 align=left valign=middle><img src='../images/icons/arrow_right.png' alt='Edit User' />
-                &nbsp;&nbsp;<a class=admin_headings href=\"useredit.php?username=$tmp_post_username&officename=$get_office\">Edit User</a></td></tr>\n";
+                &nbsp;&nbsp;<a class=admin_headings href=\"useredit.php?username=$tmp_username&officename=$get_office\">Edit User</a></td></tr>\n";
         echo "        <tr><td class=left_rows_indent height=18 align=left valign=middle><img src='../images/icons/arrow_right.png' alt='Change Password' />
-                &nbsp;&nbsp;<a class=admin_headings href=\"chngpasswd.php?username=$tmp_post_username&officename=$get_office\">Change Password</a></td>
+                &nbsp;&nbsp;<a class=admin_headings href=\"chngpasswd.php?username=$tmp_username&officename=$get_office\">Change Password</a></td>
                 </tr>\n";
         echo "        <tr><td class=left_rows_indent height=18 align=left valign=middle><img src='../images/icons/arrow_right.png' alt='Delete User' />
-                &nbsp;&nbsp;<a class=admin_headings href=\"userdelete.php?username=$tmp_post_username&officename=$get_office\">Delete User</a></td></tr>\n";
+                &nbsp;&nbsp;<a class=admin_headings href=\"userdelete.php?username=$tmp_username&officename=$get_office\">Delete User</a></td></tr>\n";
         echo "        <tr><td class=left_rows_border_top height=18 align=left valign=middle><img src='../images/icons/user_add.png' alt='Create New User' />
                 &nbsp;&nbsp;<a class=admin_headings href='usercreate.php'>Create New User</a></td></tr>\n";
         echo "        <tr><td class=left_rows height=18 align=left valign=middle><img src='../images/icons/magnifier.png' alt='User Search' />&nbsp;&nbsp;
@@ -399,37 +385,21 @@ if ($request == 'GET') {
             echo "            </table>\n";
         }
 
-        if (!empty($office_name)) {
-            $query = "select * from " . $db_prefix . "offices where officename = '" . $office_name . "'";
-            $result = mysqli_query($GLOBALS["___mysqli_ston"], $query);
-            while ($row = mysqli_fetch_array($result)) {
-                $tmp_officename = "" . $row['officename'] . "";
-            }
-            ((mysqli_free_result($result) || (is_object($result) && (get_class($result) == "mysqli_result"))) ? true : false);
-            if (!isset($tmp_officename)) {
-                echo "Office is not defined.\n";
-                exit;
-            }
+        if (!empty($office_name)
+            and is_null(tc_select_value("officename", "offices", "officename = ?", $office_name))
+        ) {
+            echo "Office is not defined.\n";
+            exit;
         }
 
-        if (!empty($group_name)) {
-            $query = "select * from " . $db_prefix . "groups where groupname = '" . $group_name . "'";
-            $result = mysqli_query($GLOBALS["___mysqli_ston"], $query);
-            while ($row = mysqli_fetch_array($result)) {
-                $tmp_groupname = "" . $row['groupname'] . "";
-            }
-            ((mysqli_free_result($result) || (is_object($result) && (get_class($result) == "mysqli_result"))) ? true : false);
-            if (!isset($tmp_officename)) {
-                echo "Group is not defined.\n";
-                exit;
-            }
+        if (!empty($group_name)
+            and is_null(tc_select_value("groupname", "groups", "groupname = ?", $group_name))
+        ) {
+            echo "Group is not defined.\n";
+            exit;
         }
 
         // end post validation //
-
-        if (!empty($string)) {
-            $display_name = stripslashes($display_name);
-        }
 
         echo "            <br />\n";
         echo "            <form name='form' action='$self' method='post'>\n";
@@ -439,8 +409,8 @@ if ($request == 'GET') {
         echo "              </tr>\n";
         echo "              <tr><td height=15></td></tr>\n";
         echo "              <tr><td class=table_rows height=25 width=20% style='padding-left:32px;' nowrap>Username:</td><td align=left class=table_rows
-                      colspan=2 width=80% style='padding-left:20px;'><input type='hidden' name='post_username'  
-                      value=\"$post_username\">$tmp_post_username</td></tr>\n";
+                      colspan=2 width=80% style='padding-left:20px;'><input type='hidden' name='post_username'
+                      value=\"$post_username\">$tmp_username</td></tr>\n";
         echo "              <tr><td class=table_rows height=25 width=20% style='padding-left:32px;' nowrap>Display Name:</td><td colspan=2 width=80%
                       style='color:red;font-family:Tahoma;font-size:10px;padding-left:20px;'>
                       <input type='text' size='25' maxlength='50' name='display_name' value=\"$display_name\">&nbsp;*</td></tr>\n";
@@ -501,24 +471,22 @@ if ($request == 'GET') {
         echo "              <tr><td height=40>&nbsp;</td></tr>\n";
         echo "                  <input type='hidden' name='get_office' value='$get_office'>\n";
         echo "              <tr><td width=30><input type='image' name='submit' value='Edit User' align='middle'
-                      src='../images/buttons/next_button.png'></td><td><a href='useradmin.php'><img src='../images/buttons/cancel_button.png' 
+                      src='../images/buttons/next_button.png'></td><td><a href='useradmin.php'><img src='../images/buttons/cancel_button.png'
                       border='0'></td></tr></table></form></td></tr>\n";
         include '../footer.php';
-        $post_username = stripslashes($post_username);
-        $display_name = stripslashes($display_name);
         exit;
     }
 
-    $post_username = stripslashes($post_username);
-    $display_name = stripslashes($display_name);
-    $post_username = addslashes($post_username);
-    $display_name = addslashes($display_name);
-
-    $query3 = "update " . $db_prefix . "employees set displayname = ('" . $display_name . "'), email = ('" . $email_addy . "'), groups = ('" . $group_name . "'),
-	   office = ('" . $office_name . "'), admin = ('" . $admin_perms . "'), reports = ('" . $reports_perms . "'), time_admin = ('" . $time_admin_perms . "'),
-           disabled = ('" . $post_disabled . "')
-           where empfullname = ('" . $post_username . "')";
-    $result3 = mysqli_query($GLOBALS["___mysqli_ston"], $query3);
+    tc_update_strings("employees", array(
+        'displayname' => $display_name,
+        'email'       => $email_addy,
+        'groups'      => $group_name,
+        'office'      => $office_name,
+        'admin'       => $admin_perms,
+        'reports'     => $reports_perms,
+        'time_admin'  => $time_admin_perms,
+        'disabled'    => $post_disabled
+    ), "empfullname = ?", $post_username);
 
     echo "<table width=100% height=89% border=0 cellpadding=0 cellspacing=1>\n";
     echo "  <tr valign=top>\n";
@@ -529,12 +497,12 @@ if ($request == 'GET') {
     echo "        <tr><td class=left_rows height=18 align=left valign=middle><img src='../images/icons/user.png' alt='User Summary' />&nbsp;&nbsp;
                 <a class=admin_headings href='useradmin.php'>User Summary</a></td></tr>\n";
     echo "        <tr><td class=current_left_rows_indent height=18 align=left valign=middle><img src='../images/icons/arrow_right.png' alt='Edit User' />
-                &nbsp;&nbsp;<a class=admin_headings href=\"useredit.php?username=$tmp_post_username&officename=$office_name\">Edit User</a></td></tr>\n";
+                &nbsp;&nbsp;<a class=admin_headings href=\"useredit.php?username=$tmp_username&officename=$office_name\">Edit User</a></td></tr>\n";
     echo "        <tr><td class=left_rows_indent height=18 align=left valign=middle><img src='../images/icons/arrow_right.png' alt='Change Password' />
-                &nbsp;&nbsp;<a class=admin_headings href=\"chngpasswd.php?username=$tmp_post_username&officename=$office_name\">Change Password</a></td>
+                &nbsp;&nbsp;<a class=admin_headings href=\"chngpasswd.php?username=$tmp_username&officename=$office_name\">Change Password</a></td>
                 </tr>\n";
     echo "        <tr><td class=left_rows_indent height=18 align=left valign=middle><img src='../images/icons/arrow_right.png' alt='Delete User' />
-                &nbsp;&nbsp;<a class=admin_headings href=\"userdelete.php?username=$tmp_post_username&officename=$office_name\">Delete User</a></td></tr>\n";
+                &nbsp;&nbsp;<a class=admin_headings href=\"userdelete.php?username=$tmp_username&officename=$office_name\">Delete User</a></td></tr>\n";
     echo "        <tr><td class=left_rows_border_top height=18 align=left valign=middle><img src='../images/icons/user_add.png' alt='Create New User' />
                 &nbsp;&nbsp;<a class=admin_headings href='usercreate.php'>Create New User</a></td></tr>\n";
     echo "        <tr><td class=left_rows height=18 align=left valign=middle><img src='../images/icons/magnifier.png' alt='User Search' />&nbsp;&nbsp;
@@ -583,15 +551,15 @@ if ($request == 'GET') {
     echo "              </tr>\n";
     echo "              <tr><td height=15></td></tr>\n";
 
-    $query4 = "select empfullname, displayname, email, groups, office, admin, reports, time_admin, disabled from " . $db_prefix . "employees
-	  where empfullname = '" . $post_username . "'
-          order by empfullname";
-    $result4 = mysqli_query($GLOBALS["___mysqli_ston"], $query4);
-
+    $result4 = tc_select(
+        "empfullname, displayname, email, groups, office, admin, reports, time_admin, disabled",
+        "employees",
+        "empfullname = ? ORDER BY empfullname",
+        $post_username
+    );
     while ($row = mysqli_fetch_array($result4)) {
-
-        $username = stripslashes("" . $row['empfullname'] . "");
-        $displayname = stripslashes("" . $row['displayname'] . "");
+        $username = "" . $row['empfullname'] . "";
+        $displayname = "" . $row['displayname'] . "";
         $user_email = "" . $row['email'] . "";
         $office = "" . $row['office'] . "";
         $groups = "" . $row['groups'] . "";
@@ -639,7 +607,7 @@ if ($request == 'GET') {
         $disabled = "No";
     }
     echo "              <tr><td class=table_rows height=25 width=20% style='padding-left:32px;' nowrap>User Account Disabled?</td><td align=left
-class=table_rows 
+class=table_rows
                       colspan=2 width=80% style='padding-left:20px;'>$disabled</td></tr>\n";
     echo "              <tr><td height=15></td></tr>\n";
     echo "            </table>\n";

--- a/admin/usersearch.php
+++ b/admin/usersearch.php
@@ -79,19 +79,16 @@ if ($request !== 'POST') {
     echo "              <tr><td height=15></td></tr>\n";
     echo "              <tr><td class=table_rows height=25 width=20% style='padding-left:32px;' nowrap>Username:</td><td colspan=2 width=80%
                       style='color:red;font-family:Tahoma;font-size:10px;padding-left:20px;'><input type='text' 
-                      size='25' maxlength='50' name='post_username' 
-                      onFocus=\"javascript:form.display_name.disabled=true;form.email_addy.disabled=true;
-                      form.display_name.style.background='#eeeeee';form.email_addy.style.background='#eeeeee';\" ></td></tr>\n";
+                      size='25' maxlength='50' name='post_username'></td></tr>\n";
     echo "              <tr><td class=table_rows height=25 width=20% style='padding-left:32px;' nowrap>Display Name:</td><td colspan=2 width=80%
                       style='color:red;font-family:Tahoma;font-size:10px;padding-left:20px;'><input type='text' 
-                      size='25' maxlength='50' name='display_name' 
-                      onFocus=\"javascript:form.post_username.disabled=true;form.email_addy.disabled=true;
-                      form.post_username.style.background='#eeeeee';form.email_addy.style.background='#eeeeee';\"></td></tr>\n";
+                      size='25' maxlength='50' name='display_name'></td></tr>\n";
     echo "              <tr><td class=table_rows height=25 width=20% style='padding-left:32px;' nowrap>Email Address:</td><td colspan=2 width=80%
                       style='color:red;font-family:Tahoma;font-size:10px;padding-left:20px;'><input type='text' 
-                      size='25' maxlength='75' name='email_addy' 
-                      onFocus=\"javascript:form.post_username.disabled=true;form.display_name.disabled=true;
-                      form.post_username.style.background='#eeeeee';form.display_name.style.background='#eeeeee';\"></td></tr>\n";
+                      size='25' maxlength='75' name='email_addy'></td></tr>\n";
+    echo "              <tr><td class=table_rows height=25 width=20% style='padding-left:32px;' nowrap>Barcode:</td><td colspan=2 width=80%
+                      style='color:red;font-family:Tahoma;font-size:10px;padding-left:20px;'><input type='text' 
+                      size='25' maxlength='75' name='barcode'></td></tr>\n";
     echo "              <tr><td class=table_rows height=25 width=20% style='padding-left:32px;' nowrap>Office:</td><td colspan=2 width=80%
                       style='padding-left:20px;'>
                       <select name='office_name' onchange='group_names();'>\n";
@@ -121,6 +118,7 @@ include 'topmain.php';
 @$post_username = $_POST['post_username'];
 @$display_name = $_POST['display_name'];
 @$email_addy = $_POST['email_addy'];
+@$barcode = $_POST['barcode'];
 @$office_name = $_POST['office_name'];
 @$group_name = $_POST['group_name'];
 
@@ -208,24 +206,24 @@ if (!preg_match('/^([[:alnum:]]|_|.|-|@)+$/', $email_addy)) {
         $evil_input = "1";
     }
 }
-if (($post_username == "") && ($display_name == "") && ($email_addy == "")) {
+if (!(has_value($post_username) || has_value($display_name) || has_value($email_addy) || has_value($barcode))) {
     echo "            <br />\n";
     echo "            <table align=center class=table_border width=60% border=0 cellpadding=0 cellspacing=3>\n";
     echo "              <tr>\n";
     echo "                <td class=table_rows width=20 align=center><img src='../images/icons/cancel.png' /></td><td class=table_rows_red nowrap>
-                    &nbsp;A Username, Display Name, or Email Address is required.</td></tr>\n";
+                    &nbsp;A Username, Display Name, Email Address, or Barcode is required.</td></tr>\n";
     echo "            </table>\n";
     $evil_input = "1";
 }
 
-if (!empty($office_name)
+if (has_value($office_name)
     and is_null(tc_select_value("officename", "offices", "officename = ?", $office_name))
 ) {
     echo "Office is not defined.\n";
     exit;
 }
 
-if (!empty($group_name)
+if (has_value($group_name)
     and is_null(tc_select_value("groupname", "groups", "groupname = ?", $group_name))
 ) {
     echo "Group is not defined.\n";
@@ -245,19 +243,16 @@ if (isset($evil_input)) {
     echo "              <tr><td height=15></td></tr>\n";
     echo "              <tr><td class=table_rows height=25 width=20% style='padding-left:32px;' nowrap>Username:</td><td colspan=2 width=80%
                       style='color:red;font-family:Tahoma;font-size:10px;padding-left:20px;'><input type='text' style='color:red;' size='25' maxlength='50' 
-                      name='post_username' value='$post_username' 
-                      onFocus=\"javascript:form.display_name.disabled=true;form.email_addy.disabled=true;
-                      form.display_name.style.background='#eeeeee';form.email_addy.style.background='#eeeeee';\"></td></tr>\n";
+                      name='post_username' value='$post_username'></td></tr>\n";
     echo "              <tr><td class=table_rows height=25 width=20% style='padding-left:32px;' nowrap>Display Name:</td><td colspan=2 width=80%
                       style='color:red;font-family:Tahoma;font-size:10px;padding-left:20px;'><input type='text' style='color:red;' size='25' maxlength='50' 
-                      name='display_name' value='$display_name' 
-                      onFocus=\"javascript:form.post_username.disabled=true;form.email_addy.disabled=true;
-                      form.post_username.style.background='#eeeeee';form.email_addy.style.background='#eeeeee';\"></td></tr>\n";
+                      name='display_name' value='$display_name'></td></tr>\n";
     echo "              <tr><td class=table_rows height=25 width=20% style='padding-left:32px;' nowrap>Email Address:</td><td colspan=2 width=80%
                       style='color:red;font-family:Tahoma;font-size:10px;padding-left:20px;'><input type='text style='color:red;' size='25' maxlength='75' 
-                      name='email_addy' value='$email_addy' 
-                      onFocus=\"javascript:form.post_username.disabled=true;form.display_name.disabled=true;
-                      form.post_username.style.background='#eeeeee';form.display_name.style.background='#eeeeee';\"></td></tr>\n";
+                      name='email_addy' value='$email_addy'></td></tr>\n";
+    echo "              <tr><td class=table_rows height=25 width=20% style='padding-left:32px;' nowrap>Barcode:</td><td colspan=2 width=80%
+                      style='color:red;font-family:Tahoma;font-size:10px;padding-left:20px;'><input type='text style='color:red;' size='25' maxlength='75' 
+                      name='barcode' value='$barcode'></td></tr>\n";
     echo "              <tr><td class=table_rows height=25 width=20% style='padding-left:32px;' nowrap>Office:</td><td colspan=2 width=80%
                       style='padding-left:20px;'>
                       <select name='office_name' onchange='group_names();'>\n";
@@ -282,43 +277,45 @@ if (isset($evil_input)) {
 
 $query_where = array();
 $query_params = array();
+$tmp_var = array();
 
-if (!empty($post_username)) {
-    $tmp_var = $post_username;
-    $tmp_var2 = "Username";
+if (has_value($post_username)) {
+    $tmp_var[] = "'$post_username' in Username";
     $query_where[] = "empfullname LIKE ?";
     $query_params[] = "%" . $post_username . "%";
 }
-elseif (!empty($display_name)) {
-    $tmp_var = $display_name;
-    $tmp_var2 = "Display Name";
+
+if (has_value($display_name)) {
+    $tmp_var[] = "'$display_name' in Display Name";
     $query_where[] = "displayname LIKE ?";
     $query_params[] = "%" . $display_name . "%";
 }
-elseif (!empty($email_addy)) {
-    $tmp_var = $email_addy;
-    $tmp_var2 = "Email Address";
+
+if (has_value($email_addy)) {
+    $tmp_var[] = "'$email_addy' in Email Address";
     $query_where[] = "email LIKE ?";
     $query_params[] = "%" . $email_addy . "%";
 }
 
-if (!empty($office_name)) {
+if (has_value($barcode)) {
+    $tmp_var[] = "'$barcode' in Barcode";
+    $query_where[] = "barcode LIKE ?";
+    $query_params[] = "%" . $barcode . "%";
+}
+
+if (has_value($office_name)) {
     $query_where[] = "office = ?";
     $query_params[] = $office_name;
 
-    if (!empty($group_name)) {
+    if (has_value($group_name)) {
         $query_where[] = "groups = ?";
         $query_params[] = $group_name;
     }
 }
 
+$tmp_var = implode(" AND ", $tmp_var);
 $row_count = "0";
-$result4 = tc_select(
-    "empfullname, displayname, email, groups, office, admin, reports, time_admin, disabled",
-    "employees",
-    implode(" AND ", $query_where) . " ORDER BY empfullname",
-    $query_params
-);
+$result4 = tc_select("*", "employees", implode(" AND ", $query_where) . " ORDER BY empfullname", $query_params);
 
 while ($row = mysqli_fetch_array($result4)) {
 
@@ -328,7 +325,7 @@ if ($row_count == "1") {
 
     echo "            <table width=90% align=center height=40 border=0 cellpadding=0 cellspacing=0>\n";
     echo "              <tr><th class=table_heading_no_color nowrap width=100% halign=left>User Search Summary</th></tr>\n";
-    echo "              <tr><td height=40 class=table_rows nowrap halign=left>Search Results for \"$tmp_var\" in $tmp_var2</td></tr>\n";
+    echo "              <tr><td height=40 class=table_rows nowrap halign=left>Search Results for $tmp_var</td></tr>\n";
     echo "            </table>\n";
     echo "            <table class=table_border width=90% align=center border=0 cellpadding=0 cellspacing=0>\n";
     echo "              <tr>\n";
@@ -452,9 +449,7 @@ echo "
                                                                                               style='color:red;'
                                                                                               size='25' maxlength='50'
                                                                                               name='post_username'
-                                                                                              value=\"$post_username\"
-                                                                                              onFocus=\"javascript:form.display_name.disabled=true;form.email_addy.disabled=true;
-                                                                                              form.display_name.style.background='#eeeeee';form.email_addy.style.background='#eeeeee';\">
+                                                                                              value=\"$post_username\">
             </td>
         </tr>
         \n";
@@ -466,9 +461,7 @@ echo "
                                                                                               style='color:red;'
                                                                                               size='25' maxlength='50'
                                                                                               name='display_name'
-                                                                                              value=\"$display_name\"
-                                                                                              onFocus=\"javascript:form.post_username.disabled=true;form.email_addy.disabled=true;
-                                                                                              form.post_username.style.background='#eeeeee';form.email_addy.style.background='#eeeeee';\">
+                                                                                              value=\"$display_name\">
             </td>
         </tr>
         \n";
@@ -479,9 +472,18 @@ echo "
                 style='color:red;font-family:Tahoma;font-size:10px;padding-left:20px;'><input type='text style='
                                                                                               color:red;' size='25'
                 maxlength='75'
-                name='email_addy' value=\"$email_addy\"
-                onFocus=\"javascript:form.post_username.disabled=true;form.display_name.disabled=true;
-                form.post_username.style.background='#eeeeee';form.display_name.style.background='#eeeeee';\">
+                name='email_addy' value=\"$email_addy\">
+            </td>
+        </tr>
+        \n";
+        echo "
+        <tr>
+            <td class=table_rows height=25 width=20% style='padding-left:32px;' nowrap>Barcode:</td>
+            <td colspan=2 width=80%
+                style='color:red;font-family:Tahoma;font-size:10px;padding-left:20px;'><input type='text style='
+                                                                                              color:red;' size='25'
+                maxlength='75'
+                name='barcode' value=\"$barcode\">
             </td>
         </tr>
         \n";

--- a/admin/usersearch.php
+++ b/admin/usersearch.php
@@ -118,16 +118,11 @@ elseif ($request == 'POST') {
 include 'header_post.php';
 include 'topmain.php';
 
-@$post_username = stripslashes($_POST['post_username']);
-@$display_name = stripslashes($_POST['display_name']);
+@$post_username = $_POST['post_username'];
+@$display_name = $_POST['display_name'];
 @$email_addy = $_POST['email_addy'];
 @$office_name = $_POST['office_name'];
 @$group_name = $_POST['group_name'];
-
-//$post_username = addslashes($post_username);
-//$display_name = addslashes($display_name);
-//$office_name = addslashes($office_name);
-//$group_name = addslashes($group_name);
 
 // begin post validation //
 
@@ -223,30 +218,18 @@ if (($post_username == "") && ($display_name == "") && ($email_addy == "")) {
     $evil_input = "1";
 }
 
-if (!empty($office_name)) {
-    $query = "select * from " . $db_prefix . "offices where officename = '" . $office_name . "'";
-    $result = mysqli_query($GLOBALS["___mysqli_ston"], $query);
-    while ($row = mysqli_fetch_array($result)) {
-        $tmp_officename = "" . $row['officename'] . "";
-    }
-    ((mysqli_free_result($result) || (is_object($result) && (get_class($result) == "mysqli_result"))) ? true : false);
-    if (!isset($tmp_officename)) {
-        echo "Office is not defined.\n";
-        exit;
-    }
+if (!empty($office_name)
+    and is_null(tc_select_value("officename", "offices", "officename = ?", $office_name))
+) {
+    echo "Office is not defined.\n";
+    exit;
 }
 
-if (!empty($group_name)) {
-    $query = "select * from " . $db_prefix . "groups where groupname = '" . $group_name . "'";
-    $result = mysqli_query($GLOBALS["___mysqli_ston"], $query);
-    while ($row = mysqli_fetch_array($result)) {
-        $tmp_groupname = "" . $row['groupname'] . "";
-    }
-    ((mysqli_free_result($result) || (is_object($result) && (get_class($result) == "mysqli_result"))) ? true : false);
-    if (!isset($tmp_officename)) {
-        echo "Group is not defined.\n";
-        exit;
-    }
+if (!empty($group_name)
+    and is_null(tc_select_value("groupname", "groups", "groupname = ?", $group_name))
+) {
+    echo "Group is not defined.\n";
+    exit;
 }
 
 // end post validation //
@@ -297,82 +280,47 @@ if (isset($evil_input)) {
 
 } else {
 
-$post_username = addslashes($post_username);
-$display_name = addslashes($display_name);
-$office_name = addslashes($office_name);
-$group_name = addslashes($group_name);
+$query_where = array();
+$query_params = array();
 
 if (!empty($post_username)) {
     $tmp_var = $post_username;
     $tmp_var2 = "Username";
-
-    if ((!empty($office_name)) && (!empty($group_name))) {
-        $query4 = "select empfullname, displayname, email, groups, office, admin, reports, time_admin, disabled from " . $db_prefix . "employees
-            where empfullname LIKE '%" . $post_username . "%' and office = '" . $office_name . "' and groups = '" . $group_name . "'
-            order by empfullname";
-        $result4 = mysqli_query($GLOBALS["___mysqli_ston"], $query4);
-    } elseif (!empty($office_name)) {
-        $query4 = "select empfullname, displayname, email, groups, office, admin, reports, time_admin, disabled from " . $db_prefix . "employees
-            where empfullname LIKE '%" . $post_username . "%' and office = '" . $office_name . "'
-            order by empfullname";
-        $result4 = mysqli_query($GLOBALS["___mysqli_ston"], $query4);
-    } elseif (empty($office_name)) {
-        $query4 = "select empfullname, displayname, email, groups, office, admin, reports, time_admin, disabled from " . $db_prefix . "employees
-            where empfullname LIKE '%" . $post_username . "%'
-            order by empfullname";
-        $result4 = mysqli_query($GLOBALS["___mysqli_ston"], $query4);
-    }
-} elseif (!empty($display_name)) {
+    $query_where[] = "empfullname LIKE ?";
+    $query_params[] = "%" . $post_username . "%";
+}
+elseif (!empty($display_name)) {
     $tmp_var = $display_name;
     $tmp_var2 = "Display Name";
-
-    if ((!empty($office_name)) && (!empty($group_name))) {
-        $query4 = "select empfullname, displayname, email, groups, office, admin, reports, time_admin, disabled from " . $db_prefix . "employees
-            where displayname LIKE '%" . $display_name . "%' and office = '" . $office_name . "' and groups = '" . $group_name . "'
-            order by empfullname";
-        $result4 = mysqli_query($GLOBALS["___mysqli_ston"], $query4);
-    } elseif (!empty($office_name)) {
-        $query4 = "select empfullname, displayname, email, groups, office, admin, reports, time_admin, disabled from " . $db_prefix . "employees
-            where displayname LIKE '%" . $display_name . "%' and office = '" . $office_name . "'
-            order by empfullname";
-        $result4 = mysqli_query($GLOBALS["___mysqli_ston"], $query4);
-    } elseif (empty($office_name)) {
-        $query4 = "select empfullname, displayname, email, groups, office, admin, reports, time_admin, disabled from " . $db_prefix . "employees
-            where displayname LIKE '%" . $display_name . "%'
-            order by empfullname";
-        $result4 = mysqli_query($GLOBALS["___mysqli_ston"], $query4);
-    }
-} elseif (!empty($email_addy)) {
+    $query_where[] = "displayname LIKE ?";
+    $query_params[] = "%" . $display_name . "%";
+}
+elseif (!empty($email_addy)) {
     $tmp_var = $email_addy;
     $tmp_var2 = "Email Address";
+    $query_where[] = "email LIKE ?";
+    $query_params[] = "%" . $email_addy . "%";
+}
 
-    if ((!empty($office_name)) && (!empty($group_name))) {
-        $query4 = "select empfullname, displayname, email, groups, office, admin, reports, time_admin, disabled from " . $db_prefix . "employees
-            where email LIKE '%" . $email_addy . "%' and office = '" . $office_name . "' and groups = '" . $group_name . "'
-            order by empfullname";
-        $result4 = mysqli_query($GLOBALS["___mysqli_ston"], $query4);
-    } elseif (!empty($office_name)) {
-        $query4 = "select empfullname, displayname, email, groups, office, admin, reports, time_admin, disabled from " . $db_prefix . "employees
-            where email LIKE '%" . $email_addy . "%' and office = '" . $office_name . "'
-            order by empfullname";
-        $result4 = mysqli_query($GLOBALS["___mysqli_ston"], $query4);
-    } elseif (empty($office_name)) {
-        $query4 = "select empfullname, displayname, email, groups, office, admin, reports, time_admin, disabled from " . $db_prefix . "employees
-            where email LIKE '%" . $email_addy . "%'
-            order by empfullname";
-        $result4 = mysqli_query($GLOBALS["___mysqli_ston"], $query4);
+if (!empty($office_name)) {
+    $query_where[] = "office = ?";
+    $query_params[] = $office_name;
+
+    if (!empty($group_name)) {
+        $query_where[] = "groups = ?";
+        $query_params[] = $group_name;
     }
 }
 
-$tmp_var = stripslashes($tmp_var);
-$tmp_var2 = stripslashes($tmp_var2);
 $row_count = "0";
+$result4 = tc_select(
+    "empfullname, displayname, email, groups, office, admin, reports, time_admin, disabled",
+    "employees",
+    implode(" AND ", $query_where) . " ORDER BY empfullname",
+    $query_params
+);
 
 while ($row = mysqli_fetch_array($result4)) {
-
-@$user_count_rows = mysqli_num_rows($user_count);
-@$admin_count_rows = mysqli_num_rows($admin_count);
-@$reports_count_rows = mysqli_num_rows($reports_count);
 
 $row_count++;
 
@@ -401,8 +349,8 @@ if ($row_count == "1") {
 }
 
 $row_color = ($row_count % 2) ? $color2 : $color1;
-$empfullname = stripslashes("" . $row['empfullname'] . "");
-$displayname = stripslashes("" . $row['displayname'] . "");
+$empfullname = "" . $row['empfullname'] . "";
+$displayname = "" . $row['displayname'] . "";
 
 echo "              <tr class=table_border bgcolor='$row_color'><td class=table_rows width=3%>&nbsp;$row_count</td>\n";
 echo "                <td class=table_rows width=13%>&nbsp;<a class=footer_links title=\"Edit User: $empfullname\"
@@ -463,8 +411,6 @@ echo "              </tr>\n";
 ((mysqli_free_result($result4) || (is_object($result4) && (get_class($result4) == "mysqli_result"))) ? true : false);
 
 if ($row_count == "0") {
-
-$post_username = stripslashes($post_username);
 
 echo "            <br/>\n";
 echo "

--- a/config.inc.php
+++ b/config.inc.php
@@ -87,6 +87,24 @@ $use_passwd = "yes";
 $use_reports_password = "no";
 
 
+/* Choose whether to allow barcode clock-in/out. Options are "yes" or "no".
+   If "yes" is chosen, the barcode entry will be visible and focused by
+   default on the main timeclock screen. Scanning the employee barcode will
+   immediately change their status.
+*/
+
+$barcode_clockin = "yes";
+
+
+/* Choose whether to allow selecting employee name from dropdown to
+   clock-in/out. Options are "yes" or "no". If "yes" is chosen, the a
+   dropdown (and password entry if enabled) will be displayed on the
+   timeclock screen and employees will be able to change their status.
+*/
+
+$manual_clockin = "yes";
+
+
 /* Enable the option to log the ip addresses of the connecting computers when users
    punch-in/out, or when a time is manually added, edited, or deleted. Default is
    "yes". */

--- a/config.inc.php
+++ b/config.inc.php
@@ -420,7 +420,7 @@ $city = "Topeka, KS";
 
 
 $app_name = "PHP Timeclock";
-$app_version = "1.04";
+$app_version = "2.0.0";
 
 /* Sets the title in the header. This is what the page will be named by default when you
    make a "favorite" or "bookmark" in your browser. Change as you see fit. */

--- a/create_tables.sql
+++ b/create_tables.sql
@@ -1,41 +1,47 @@
-# if you would like to utilize a table prefix when creating these tables, be sure to reflect that in config.inc.php so the program
-# will be aware of it. this option is $db_prefix. if you are unaware of what is meant by utilizing a 'table prefix', then please disregard.
+
+-- if you would like to utilize a table prefix when creating these tables,
+-- be sure to reflect that in config.inc.php so the program will be aware
+-- of it. this option is $db_prefix. if you are unaware of what is meant by
+-- utilizing a 'table prefix', then please disregard.
+
 
 -- --------------------------------------------------------
-
 --
 -- Table structure for table `audit`
 --
 
 CREATE TABLE `audit` (
-  `modified_by_ip` varchar(39) COLLATE utf8_bin NOT NULL DEFAULT '',
-  `modified_by_user` varchar(50) COLLATE utf8_bin NOT NULL DEFAULT '',
-  `modified_when` bigint(14) NOT NULL,
+  `modified_when` bigint(14),
   `modified_from` bigint(14) NOT NULL,
   `modified_to` bigint(14) NOT NULL,
+  `modified_by_ip` varchar(39) COLLATE utf8_bin NOT NULL DEFAULT '',
+  `modified_by_user` varchar(50) COLLATE utf8_bin NOT NULL DEFAULT '',
   `modified_why` varchar(250) COLLATE utf8_bin NOT NULL DEFAULT '',
   `user_modified` varchar(50) COLLATE utf8_bin NOT NULL DEFAULT ''
 ) ENGINE=MyISAM DEFAULT CHARSET=utf8 COLLATE=utf8_bin;
 
--- --------------------------------------------------------
+CREATE INDEX audit_modified_when ON audit (modified_when);
 
+
+-- --------------------------------------------------------
 --
 -- Table structure for table `dbversion`
 --
 
 CREATE TABLE `dbversion` (
-  `dbversion` decimal(5,1) NOT NULL DEFAULT '0.0'
+  `dbversion` decimal(5,1) PRIMARY KEY
 ) ENGINE=MyISAM DEFAULT CHARSET=utf8 COLLATE=utf8_bin;
 
 INSERT INTO dbversion VALUES ('1.4');
--- --------------------------------------------------------
 
+
+-- --------------------------------------------------------
 --
 -- Table structure for table `employees`
 --
 
 CREATE TABLE `employees` (
-  `empfullname` varchar(50) COLLATE utf8_bin NOT NULL DEFAULT '',
+  `empfullname` varchar(50) PRIMARY KEY COLLATE utf8_bin,
   `tstamp` bigint(14) DEFAULT NULL,
   `employee_passwd` varchar(25) COLLATE utf8_bin NOT NULL DEFAULT '',
   `displayname` varchar(50) COLLATE utf8_bin NOT NULL DEFAULT '',
@@ -48,20 +54,20 @@ CREATE TABLE `employees` (
   `disabled` tinyint(1) NOT NULL DEFAULT '0'
 ) ENGINE=MyISAM DEFAULT CHARSET=utf8 COLLATE=utf8_bin;
 
--- --------------------------------------------------------
 
+-- --------------------------------------------------------
 --
 -- Table structure for table `groups`
 --
 
 CREATE TABLE `groups` (
+  `groupid` int(10)  AUTO_INCREMENT PRIMARY KEY,
   `groupname` varchar(50) COLLATE utf8_bin NOT NULL DEFAULT '',
-  `groupid` int(10) NOT NULL,
   `officeid` int(10) NOT NULL DEFAULT '0'
 ) ENGINE=MyISAM DEFAULT CHARSET=utf8 COLLATE=utf8_bin;
 
--- --------------------------------------------------------
 
+-- --------------------------------------------------------
 --
 -- Table structure for table `info`
 --
@@ -74,118 +80,53 @@ CREATE TABLE `info` (
   `ipaddress` varchar(39) COLLATE utf8_bin NOT NULL DEFAULT ''
 ) ENGINE=MyISAM DEFAULT CHARSET=utf8 COLLATE=utf8_bin;
 
--- --------------------------------------------------------
+CREATE INDEX info_fullname  ON info (fullname);
+CREATE INDEX info_timestamp ON info (`timestamp`);
 
+
+-- --------------------------------------------------------
 --
 -- Table structure for table `metars`
 --
 
 CREATE TABLE `metars` (
+  `station` varchar(4) PRIMARY KEY COLLATE utf8_bin,
   `metar` varchar(255) COLLATE utf8_bin NOT NULL DEFAULT '',
-  `timestamp` timestamp NOT NULL,
-  `station` varchar(4) COLLATE utf8_bin NOT NULL DEFAULT ''
+  `timestamp` timestamp NOT NULL
 ) ENGINE=MyISAM DEFAULT CHARSET=utf8 COLLATE=utf8_bin;
 
--- --------------------------------------------------------
 
+-- --------------------------------------------------------
 --
 -- Table structure for table `offices`
 --
 
 CREATE TABLE `offices` (
-  `officename` varchar(50) COLLATE utf8_bin NOT NULL DEFAULT '',
-  `officeid` int(10) NOT NULL
+  `officeid` int(10) AUTO_INCREMENT PRIMARY KEY,
+  `officename` varchar(50) COLLATE utf8_bin NOT NULL DEFAULT ''
 ) ENGINE=MyISAM DEFAULT CHARSET=utf8 COLLATE=utf8_bin;
 
--- --------------------------------------------------------
 
+-- --------------------------------------------------------
 --
 -- Table structure for table `punchlist`
 --
 
 CREATE TABLE `punchlist` (
-  `punchitems` varchar(50) COLLATE utf8_bin NOT NULL DEFAULT '',
+  `punchitems` varchar(50) PRIMARY KEY COLLATE utf8_bin,
   `color` varchar(7) COLLATE utf8_bin NOT NULL DEFAULT '',
   `in_or_out` tinyint(1) DEFAULT NULL
 ) ENGINE=MyISAM DEFAULT CHARSET=utf8 COLLATE=utf8_bin;
 
+
+-- --------------------------------------------------------
 --
--- Indexes for dumped tables
+-- Insert default data. Version, admin login, etc.
 --
 
---
--- Indexes for table `audit`
---
-ALTER TABLE `audit`
-  ADD PRIMARY KEY (`modified_when`),
-  ADD UNIQUE KEY `modified_when` (`modified_when`);
-
---
--- Indexes for table `dbversion`
---
-ALTER TABLE `dbversion`
-  ADD PRIMARY KEY (`dbversion`);
-
---
--- Indexes for table `employees`
---
-ALTER TABLE `employees`
-  ADD PRIMARY KEY (`empfullname`);
-
---
--- Indexes for table `groups`
---
-ALTER TABLE `groups`
-  ADD PRIMARY KEY (`groupid`);
-
---
--- Indexes for table `info`
---
-ALTER TABLE `info`
-  ADD KEY `fullname` (`fullname`);
-
---
--- Indexes for table `metars`
---
-ALTER TABLE `metars`
-  ADD PRIMARY KEY (`station`),
-  ADD UNIQUE KEY `station` (`station`);
-
---
--- Indexes for table `offices`
---
-ALTER TABLE `offices`
-  ADD PRIMARY KEY (`officeid`);
-
---
--- Indexes for table `punchlist`
---
-ALTER TABLE `punchlist`
-  ADD PRIMARY KEY (`punchitems`);
-
---
--- AUTO_INCREMENT for dumped tables
---
-
---
--- AUTO_INCREMENT for table `groups`
---
-ALTER TABLE `groups`
-  MODIFY `groupid` int(10) NOT NULL AUTO_INCREMENT, AUTO_INCREMENT=3;
---
--- AUTO_INCREMENT for table `offices`
---
-ALTER TABLE `offices`
-  MODIFY `officeid` int(10) NOT NULL AUTO_INCREMENT, AUTO_INCREMENT=2;
-  
-  --
-  -- Insert default data. Version, admin login, etc. 
-  --
-  
-  INSERT INTO employees VALUES ('admin', NULL, 'xy.RY2HT1QTc2', 'administrator', '', '', '', 1, 1, 1, '');
-  INSERT INTO dbversion VALUES ('1.4');
-  INSERT INTO punchlist VALUES ('in', '#009900', 1);
-  INSERT INTO punchlist VALUES ('out', '#FF0000', 0);
-  INSERT INTO punchlist VALUES ('break', '#FF9900', 0);
-  INSERT INTO punchlist VALUES ('lunch', '#0000FF', 0);
-  
+INSERT INTO employees VALUES ('admin', NULL, 'xy.RY2HT1QTc2', 'administrator', '', '', '', 1, 1, 1, '');
+INSERT INTO dbversion VALUES ('1.4');
+INSERT INTO punchlist VALUES ('in', '#009900', 1);
+INSERT INTO punchlist VALUES ('out', '#FF0000', 0);
+INSERT INTO punchlist VALUES ('break', '#FF9900', 0);
+INSERT INTO punchlist VALUES ('lunch', '#0000FF', 0);

--- a/docs/CHANGELOG
+++ b/docs/CHANGELOG
@@ -1,10 +1,13 @@
-PHP Timeclock
-Version 1.04
-http://sourceforge.net/projects/timeclock
+PHP Timeclock Changelog
 Copyright (C) 2006 Ken Papizan <pappyzan_at_users.sourceforge.net>
 
 
-PHP Timeclock Changelog
+PHP Timeclock  2.0.0  released 2017-03-09
+
+  * Barcode punch in/out
+
+
+
 
 1.04  11/15/07
 -----------------------

--- a/docs/CREDITS
+++ b/docs/CREDITS
@@ -1,6 +1,4 @@
 PHP Timeclock
-Version 1.04
-http://sourceforge.net/projects/timeclock
 Copyright (C) 2006 Ken Papizan <pappyzan_at_users.sourceforge.net>
 
 

--- a/docs/INSTALL
+++ b/docs/INSTALL
@@ -1,6 +1,4 @@
 PHP Timeclock
-Version 1.04
-http://sourceforge.net/projects/timeclock
 Copyright (C) 2006 Ken Papizan <pappyzan_at_users.sourceforge.net>
 
 
@@ -12,67 +10,66 @@ REQUIREMENTS:
 --- Javascript enabled web browser
 
 
-TESTED:
+TESTED CONFIGURATIONS:
 
---- PHP 4.34, 5.1.2 with mysql support
---- MySQL 3.23.49, 4.0.17, 5.0.18
---- Apache 1.3.22, 1.3.29, 2.2.0
---- Firefox 1.0 - 1.5.0.4, Firefox 1.0 Preview Release, IE 6.0 SP1, IE 6.0 SP2 for XP, IE 7.0 beta 2
-
-Any version of mysql or webserver software that supports php, whether it's an earlier 
-version than what's tested or later, will probably work fine. Any web browser that supports
-css2 should work fine (IE5+, Mozilla 1.0+, Firefox). 
-
-***********************************************************************************************
-Beginning with version 0.9.4, an option has been provided to display punch-in/out times 
-according to the timezone of the connecting client system. The client must enable cookies and 
-javascript in their web browser in order to take advantage of this option.
-***********************************************************************************************
+Debian 8.0 (Jessie): PHP 5.6.30, MariaDB 10.0, Apache 2.4.10
+    packages: apache2 libapache2-mod-php5 php5-mysqlnd
+    A Dockerfile is available at: https://github.com/duelafn/dockerfiles/tree/master/timecard
 
 
 INSTALLATION:
 
 New Install
 -----------
---- Unpack the distribution into your webserver's document root directory. 
+--- Unpack the distribution into your webserver's document root directory.
 --- Create a database named "timeclock" or whatever you wish to name it.
 --- Create a mysql user named "timeclock" (or whatever you wish to name it) with a password.
-    Give this user at least SELECT, UPDATE, INSERT, DELETE, ALTER, and CREATE privileges to ONLY 
+    Give this user at least SELECT, UPDATE, INSERT, DELETE, ALTER, and CREATE privileges to ONLY
     this database.
 --- Import the tables using the create_tables.sql script included in this distribution.
 --- Edit config.inc.php.
 --- Open index.php with your web browser.
---- Click on the Administration link on the right side of the page. Input "admin" (without the quotes) 
-    for the username and "admin" (without the quotes) for the password. Please change the password 
+--- Click on the Administration link on the right side of the page. Input "admin" (without the quotes)
+    for the username and "admin" (without the quotes) for the password. Please change the password
     for this admin user after the initial setup of PHP Timeclock is complete.
---- Create at least one office by clicking on the Create Office link on the left side of the page. 
+--- Create at least one office by clicking on the Create Office link on the left side of the page.
     You MUST create an office to achieve the desired results. Create more offices if needed.
---- Create at least one group by clicking on the Create Group link on the left side of the page. 
+--- Create at least one group by clicking on the Create Group link on the left side of the page.
     You MUST create a group to achieve the desired results. Create more groups if needed.
 --- Add your users by clicking on the Create New Users link, and assign them to the office(s) and
-    group(s) you created above. Give Sys Admin level access for users who will administrate 
-    PHP Timeclock. Give Time Admin level access for users who will need to edit users' time, but 
-    who will not need Sys Admin level access. If you require the reports to be secured so only 
-    certain users can run them, then give these users reports level access. 
+    group(s) you created above. Give Sys Admin level access for users who will administrate
+    PHP Timeclock. Give Time Admin level access for users who will need to edit users' time, but
+    who will not need Sys Admin level access. If you require the reports to be secured so only
+    certain users can run them, then give these users reports level access.
 
-    *** Admin level access and reports level access are completely separate from each other. Just 
-    *** because a user has admin level access does not give that user reports level access. You must 
-    *** specifically give them reports level access when you are creating or editing the users, 
-    *** if you choose to secure these reports for these users. To make PHP Timeclock lock down the 
+    *** Admin level access and reports level access are completely separate from each other. Just
+    *** because a user has admin level access does not give that user reports level access. You must
+    *** specifically give them reports level access when you are creating or editing the users,
+    *** if you choose to secure these reports for these users. To make PHP Timeclock lock down the
     *** reports to only these users, set the use_reports_password setting in config.inc.php to "yes".
+
+
+Upgrading from 1.04
+-------------------
+--- Backup and move your current installation.
+--- Unpack the distribution into your webserver's document root directory.
+--- Edit config.inc.php or simply replace the new config.inc.php with your previous config.inc.php.
+--- Either login to PHP Timeclock and run the Upgrade Database script within the Admin section, or
+    upgrade the database by running the upgrade scripts in the "sql" directory, one at a time, until
+    your database is upgraded to the latest version.
 
 
 Upgrading from 1.02 or 1.03
 ---------------------------
 --- Backup and move your current installation.
---- Unpack the distribution into your webserver's document root directory. 
+--- Unpack the distribution into your webserver's document root directory.
 --- Edit config.inc.php or simply replace the new config.inc.php with your previous config.inc.php.
 
 
 Upgrading from 1.01 or 1.0
 --------------------------
 --- Backup and move your current installation.
---- Unpack the distribution into your webserver's document root directory. 
+--- Unpack the distribution into your webserver's document root directory.
 --- Edit config.inc.php.
 --- Either login to PHP Timeclock and run the Upgrade Database script within the Admin section, or
     upgrade the database by running the queries that are contained in the alter_tables.sql script.
@@ -81,44 +78,42 @@ Upgrading from 1.01 or 1.0
 Upgrading from 0.9.4 or 0.9.4-1
 -------------------------------
 --- Backup and move your current installation.
---- Unpack the distribution into your webserver's document root directory. 
---- Upgrade the database by running the queries that are contained in the 
+--- Unpack the distribution into your webserver's document root directory.
+--- Upgrade the database by running the queries that are contained in the
     alter_tables.sql script included in this distribution against the PHP Timeclock
-    database. The Upgrade Database link in the Administration section of PHP Timeclock will 
-    not work for this particular upgrade since the admin user needs to be added to the database 
-    initially. Meaning, you cannot even get to the Upgrade Database page until the admin user 
+    database. The Upgrade Database link in the Administration section of PHP Timeclock will
+    not work for this particular upgrade since the admin user needs to be added to the database
+    initially. Meaning, you cannot even get to the Upgrade Database page until the admin user
     is added to the database.
 --- Edit config.inc.php.
 --- Open index.php with your web browser.
---- Click on the Administration link on the right side of the page. Input "admin" (without the quotes) 
-    for the username and "admin" (without the quotes) for the password. Please change the password 
+--- Click on the Administration link on the right side of the page. Input "admin" (without the quotes)
+    for the username and "admin" (without the quotes) for the password. Please change the password
     for this admin user after the initial setup of PHP Timeclock is complete.
---- Create at least one office by clicking on the Create Office link on the left side of the page. 
+--- Create at least one office by clicking on the Create Office link on the left side of the page.
     You MUST create an office to achieve the desired results. Create more offices if needed.
---- Create at least one group by clicking on the Create Group link on the left side of the page. 
+--- Create at least one group by clicking on the Create Group link on the left side of the page.
     You MUST create a group to achieve the desired results. Create more groups if needed.
---- Edit your users by clicking on the User Summary link, then click on their username, and then 
-    assign them to the office(s) and group(s) you created above. Give Sys Admin level access for 
-    users who will administrate PHP Timeclock. Give Time Admin level access for users who will 
+--- Edit your users by clicking on the User Summary link, then click on their username, and then
+    assign them to the office(s) and group(s) you created above. Give Sys Admin level access for
+    users who will administrate PHP Timeclock. Give Time Admin level access for users who will
     need to edit users' time, but who will not need Sys Admin level access. If you require the
     reports to be secured so only certain users can run them, then give these users reports
-    level access. 
+    level access.
 
-    *** Admin level access and reports level access are completely separate from each other. Just 
-    *** because a user has admin level access does not give that user reports level access. You must 
-    *** specifically give them reports level access when you are creating or editing the users, 
-    *** if you choose to secure these reports for these users. To make PHP Timeclock lock down the 
+    *** Admin level access and reports level access are completely separate from each other. Just
+    *** because a user has admin level access does not give that user reports level access. You must
+    *** specifically give them reports level access when you are creating or editing the users,
+    *** if you choose to secure these reports for these users. To make PHP Timeclock lock down the
     *** reports to only these users, set the use_reports_password setting in config.inc.php to "yes".
 
 
-Upgrading from releases prior to 0.9.4 
+Upgrading from releases prior to 0.9.4
 --------------------------------------
 --- The best way to upgrade from versions prior to 0.9.4 is to download version 0.9.4
     and upgrade to that version first. Then follow the upgrade instructions included
-    in that version of the distribution. 
+    in that version of the distribution.
 
     The reason for doing it this way is that the timestamps are stored differently for versions
-    0.9.4 and higher than in previous versions. Upgrading to 0.9.4 first will preserve the 
+    0.9.4 and higher than in previous versions. Upgrading to 0.9.4 first will preserve the
     punch-in/out history for each user.
-
-

--- a/docs/README
+++ b/docs/README
@@ -1,6 +1,4 @@
 PHP Timeclock
-Version 1.04
-http://sourceforge.net/projects/timeclock
 Copyright (C) 2006 Ken Papizan <pappyzan_at_users.sourceforge.net>
 
 

--- a/docs/TODO
+++ b/docs/TODO
@@ -1,6 +1,4 @@
 PHP Timeclock
-Version 1.04
-http://sourceforge.net/projects/timeclock
 Copyright (C) 2006 Ken Papizan <pappyzan_at_users.sourceforge.net>
 
 

--- a/footer.php
+++ b/footer.php
@@ -2,17 +2,13 @@
 
 // display 'Powered by' info in bottom right of each page //
 
-echo "        <tr class=hide><td height=4% class=misc_items align=right valign=middle scope=row colspan=2>Powered by&nbsp;<a class=footer_links 
-            href='http://httpd.apache.org/'>Apache</a>&nbsp;&#177<a class=footer_links href='http://mysql.org'>&nbsp;MySql</a> 
-            &#177";
+echo "        <tr class=hide><td height=4% class=misc_items align=right valign=middle scope=row colspan=2>";
 
-if ($email == "none") {
-    echo "<a class=footer_links href='http://php.net'>&nbsp;PHP</a>";
-} else {
-    echo "<a class=footer_links href='http://php.net'>&nbsp;PHP</a>&nbsp;&#8226;&nbsp;<a class=footer_links href='mailto:$email'>$email</a>";
+if ($email != "none") {
+    echo "<a class=footer_links href='mailto:$email'>$email</a>&nbsp;&#8226;&nbsp;";
 }
 
-echo "&nbsp;&#8226;<a class=footer_links href='http://timeclock.sourceforge.net'>&nbsp;$app_name&nbsp;$app_version</a></td></tr>\n";
+echo "<a class=footer_links href='https://github.com/BoatrightTBC/timeclock'>$app_name&nbsp;$app_version</a></td></tr>\n";
 echo "      </table>\n";
 echo "    </td>\n";
 echo "  </tr>\n";

--- a/functions.php
+++ b/functions.php
@@ -111,7 +111,46 @@ function tc_update_strings($db, $keyvals, $where = '1=1', $bind = array(), $type
     tc_execute("UPDATE ${db_prefix}$db SET $places WHERE $where", array_merge($values, $bind), $types);
 }
 
+function btag($tag, $attr = array()) {
+    $begin = array(htmlentities($tag));
+    foreach ($attr as $key => $value) {
+        $begin[] = htmlentities($key) . "=\"" . htmlentities($value) . "\"";
+    }
+    return "<" . implode(" ", $begin) . ">";
+}
 
+function tag($tag, $content = "", $attr = array()) {
+    return btag($tag, $attr) . htmlentities($content) . "</" . htmlentities($tag) . ">";
+}
+
+function html_options($result, $selected='') {
+    $rv = array();
+    while ($row = mysqli_fetch_array($result)) {
+        $value = htmlentities($row[0]);
+        $display = htmlentities(is_null(@$row[1]) ? $row[0] : $row[1]);
+        $sel = ($row[0] == $selected) ? " selected" : "";
+        $rv[] = "<option value=\"$value\"$sel>$display</option>\n";
+    }
+    return implode("", $rv);
+}
+
+function yes_no_bool($val, $default=false) {
+    if (strtolower(@$val) == 'yes') {
+        return true;
+    }
+    if (strtolower(@$val) == 'no') {
+        return false;
+    }
+    return $default;
+}
+
+function value_or_null($val) {
+    return ((strlen(trim(@$val)) == 0) ? null : $val);
+}
+
+function has_value($val) {
+    return (strlen(trim(@$val)) != 0);
+}
 
 function secsToHours($secs, $round_time) {
 

--- a/functions.php
+++ b/functions.php
@@ -1,5 +1,118 @@
 <?php
 
+function _tc_bind_param($stmt, $params, $types) {
+    if (is_null($params)) {
+        $params = array();
+    }
+
+    if (!is_array($params)) {
+        $params = array($params);
+    }
+
+    if (empty($params)) { return; }
+
+    if (is_null($types)) {
+        $types = str_repeat("s", count($params));
+    }
+
+    $refs = array();
+    foreach ($params as $key => $value) {
+        $refs[$key] = &$params[$key];
+    }
+    array_unshift($refs, $types);
+    return call_user_func_array(array($stmt, 'bind_param'), @$refs);
+}
+
+function tc_execute($query, $params = array(), $types = null) {
+    if (!($stmt = $GLOBALS["___mysqli_ston"]->prepare($query))) {
+        error_log("Failed to prepare $query: " . mysqli_error($GLOBALS["___mysqli_ston"]));
+        return false;
+    }
+    _tc_bind_param($stmt, $params, $types);
+    if (!$stmt->execute()) {
+        error_log("Failed to execute: " . $stmt->error);
+        return false;
+    }
+    return $stmt->close();
+}
+
+function tc_query($query, $params = array(), $types = null) {
+    if (!($stmt = $GLOBALS["___mysqli_ston"]->prepare($query))) {
+        error_log("Failed to prepare $query: " . mysqli_error($GLOBALS["___mysqli_ston"]));
+        return false;
+    }
+    _tc_bind_param($stmt, $params, $types);
+    if (!$stmt->execute()) {
+        error_log("Failed to execute: " . $stmt->error);
+        return false;
+    }
+    return $stmt->get_result();
+}
+
+function tc_select($what, $from, $where = '1=1', $params = array(), $types = null) {
+    global $db_prefix;
+    return tc_query("SELECT $what FROM ${db_prefix}$from WHERE $where", $params, $types);
+}
+
+function tc_select_value($what, $from, $where = '1=1', $params = array(), $types = null) {
+    global $db_prefix;
+    $result = tc_query("SELECT $what FROM ${db_prefix}$from WHERE $where", $params, $types);
+    $value = null;
+    while ($row = mysqli_fetch_array($result)) {
+        $value = $row[0];
+    }
+    return $value;
+}
+
+function tc_delete($from, $where, $params = array(), $types = null) {
+    global $db_prefix;
+    return tc_query("DELETE FROM ${db_prefix}$from WHERE $where", $params, $types);
+}
+
+function tc_insert_strings($db, $keyvals) {
+    global $db_prefix;
+    $keys = '';
+    $places = '';
+    $types = '';
+    $values = array();
+    foreach ($keyvals as $key => $value) {
+        if (!empty($keys)) {
+            $keys .= ",";
+            $places .= ",";
+        }
+        $keys .= "`$key`";
+        $places .= "?";
+        $types .= "s";
+        $values[] = "$value";
+    }
+    tc_execute("INSERT INTO ${db_prefix}$db ($keys) VALUES ($places)", $values, $types);
+    return mysqli_insert_id($GLOBALS["___mysqli_ston"]);
+}
+
+function tc_update_strings($db, $keyvals, $where = '1=1', $bind = array(), $types = null) {
+    global $db_prefix;
+    $places = '';
+    $set_types = '';
+    $values = array();
+    foreach ($keyvals as $key => $value) {
+        if (!empty($places)) {
+            $places .= ",";
+        }
+        $places .= "`$key` = ?";
+        $set_types .= "s";
+        $values[] = "$value";
+    }
+    if (!is_array($bind)) {
+        $bind = array($bind);
+    }
+    if (!is_null($types)) {
+        $types = $set_types . $types;
+    }
+    tc_execute("UPDATE ${db_prefix}$db SET $places WHERE $where", array_merge($values, $bind), $types);
+}
+
+
+
 function secsToHours($secs, $round_time) {
 
     /* The logic for this function was written by Adam Woodbeck, who initially wrote it to round to the

--- a/leftmain.php
+++ b/leftmain.php
@@ -18,6 +18,7 @@ if ($request == 'POST') {
     @$reset_cookie = $_POST['reset_cookie'];
     @$fullname = $_POST['left_fullname'];
     @$displayname = $_POST['left_displayname'];
+    @$barcode = (yes_no_bool($barcode_clockin) ? $_POST['left_barcode'] : "");
     if ((isset($remember_me)) && ($remember_me != '1')) {
         echo "Something is fishy here.\n";
         exit;
@@ -28,37 +29,52 @@ if ($request == 'POST') {
     }
 
     // begin post validation //
+    $errors = array();
 
-    if ($show_display_name == "yes") {
-
-        if (isset($displayname)) {
-            $tmp_displayname = tc_select_value("displayname", "employees", "displayname = ?", $displayname);
-            if ((!isset($tmp_displayname)) && (!empty($displayname))) {
-                echo "Username is not in the database.\n";
-                exit;
-            }
-            $emp_name = $tmp_displayname;
+    if (has_value($barcode)) {
+        $tmp_name = tc_select_value($emp_name_field, "employees", "barcode = ?", $barcode);
+        if (!has_value($tmp_name)) {
+            $errors[] = "Invalid barcode '$barcode'";
+        } elseif (isset($emp_name) and $emp_name != $tmp_name) {
+            $errors[] = "Username / Barcode mismatch";
+        } else {
+            $emp_name = $tmp_name;
         }
+    }
 
-    } elseif ($show_display_name == "no") {
-
-        if (isset($fullname)) {
-            $tmp_empfullname = tc_select_value("empfullname", "employees", "empfullname = ?", $fullname);
-            if ((!isset($tmp_empfullname)) && (!empty($fullname))) {
-                echo "Username is not in the database.\n";
-                exit;
+    $tmp_name = '';
+    if (yes_no_bool($show_display_name)) {
+        if (has_value($displayname)) {
+            $tmp_name = tc_select_value($emp_name_field, "employees", "displayname = ?", $displayname);
+            if (!has_value($tmp_name)) {
+                $errors[] = "Invalid username '$displayname'";
             }
-            $emp_name = $tmp_empfullname;
         }
+    } else {
+        if (has_value($fullname)) {
+            $tmp_name = tc_select_value($emp_name_field, "employees", "empfullname = ?", $fullname);
+            if (!has_value($tmp_name)) {
+                $errors[] = "Invalid username '$fullname'";
+            }
+        }
+    }
 
+    if (has_value($tmp_name)) {
+        if (isset($emp_name) and $emp_name != $tmp_name) {
+            $errors[] = "Username / Barcode mismatch";
+        } else {
+            $emp_name = $tmp_name;
+        }
     }
 
     // end post validation //
 
-    if (isset($remember_me)) {
-        setcookie("remember_me", $emp_name, time() + (60 * 60 * 24 * 365 * 2));
-    } elseif (isset($reset_cookie)) {
-        setcookie("remember_me", "", time() - 3600);
+    if (empty($errors)) {
+        if (isset($remember_me)) {
+            setcookie("remember_me", $emp_name, time() + (60 * 60 * 24 * 365 * 2));
+        } elseif (isset($reset_cookie)) {
+            setcookie("remember_me", "", time() - 3600);
+        }
     }
 
     ob_end_flush();
@@ -87,7 +103,7 @@ if ($links == "none") {
 
 // display form to submit signin/signout information //
 
-echo "        <form name='timeclock' action='$self' method='post'>\n";
+echo "        <form name='timeclock' action='$self' autocomplete='off' method='post'>\n";
 
 if ($links == "none") {
     echo "        <tr><td height=7></td></tr>\n";
@@ -95,84 +111,85 @@ if ($links == "none") {
     echo "        <tr><td height=20></td></tr>\n";
 }
 
-echo "        <tr><td class=title_underline height=4 align=left valign=middle style='padding-left:10px;'>Please sign in below:</td></tr>\n";
-echo "        <tr><td height=7></td></tr>\n";
-echo "        <tr><td height=4 align=left valign=middle class=misc_items>Name:</td></tr>\n";
-echo "        <tr><td height=4 align=left valign=middle class=misc_items>\n";
-
-// query to populate dropdown with employee names //
-
-if ($show_display_name == "yes") {
-    echo "              <select name='left_displayname' tabindex=1>\n";
-} else {
-    echo "              <select name='left_fullname' tabindex=1>\n";
+if (yes_no_bool($barcode_clockin)) {
+    echo <<<BARCODE_CLOCKIN
+        <tr><td height="4" align="left" valign="middle" class="misc_items">Barcode:</td></tr>
+        <tr><td height="4" align="left" valign="middle" class="misc_items">
+            <input type="text" id="left_barcode" name="left_barcode" maxlength="250" size="17" value="" autocomplete="off" autofocus>
+            <input type="text" style="display:none;"><!-- prevent login name auto-fill due to password field below -->
+        </td></tr>
+        <tr><td height="7"></td></tr>
+BARCODE_CLOCKIN;
 }
 
-$emp_name_result = tc_select($emp_name_field, "employees", "disabled <> '1' AND empfullname <> 'admin' ORDER BY $emp_name_field");
-echo "              <option value =''>...</option>\n";
-while ($row = mysqli_fetch_array($emp_name_result)) {
-    $abc = "" . $row[$emp_name_field] . "";
+if (yes_no_bool($barcode_clockin) and yes_no_bool($manual_clockin)) {
+    echo '<tr><td height="7"><hr></td></tr>';
+}
 
-    if ((isset($_COOKIE['remember_me'])) && ($_COOKIE['remember_me'] == $abc)) {
-        echo "              <option selected>$abc</option>\n";
+if (yes_no_bool($manual_clockin)) {
+    echo "        <tr><td class=title_underline height=4 align=left valign=middle style='padding-left:10px;'>Please sign in below:</td></tr>\n";
+    echo "        <tr><td height=7></td></tr>\n";
+    echo "        <tr><td height=4 align=left valign=middle class=misc_items>Name:</td></tr>\n";
+    echo "        <tr><td height=4 align=left valign=middle class=misc_items>\n";
+
+    // query to populate dropdown with employee names //
+
+    if ($show_display_name == "yes") {
+        echo "              <select name='left_displayname'>\n";
     } else {
-        echo "              <option>$abc</option>\n";
+        echo "              <select name='left_fullname'>\n";
     }
-}
-echo "              </select></td></tr>\n";
-((mysqli_free_result($emp_name_result) || (is_object($emp_name_result) && (get_class($emp_name_result) == "mysqli_result"))) ? true : false);
-echo "        <tr><td height=7></td></tr>\n";
 
+    echo "              <option value =''>...</option>\n";
+    echo html_options(
+        tc_select($emp_name_field, "employees", "disabled <> '1' AND empfullname <> 'admin' ORDER BY $emp_name_field"),
+        @$_COOKIE['remember_me']
+    );
+    echo "              </select></td></tr>\n";
+    echo "        <tr><td height=7></td></tr>\n";
 
-// determine whether to use encrypted passwords or not //
+    // determine whether to use encrypted passwords or not //
 
-if ($use_passwd == "yes") {
-    echo "        <tr><td height=4 align=left valign=middle class=misc_items>Password:</td></tr>\n";
+    if ($use_passwd == "yes") {
+        echo "        <tr><td height=4 align=left valign=middle class=misc_items>Password:</td></tr>\n";
+        echo "        <tr><td height=4 align=left valign=middle class=misc_items>";
+        echo "<input type='password' name='employee_passwd' maxlength='25' size='17'></td></tr>\n";
+        echo "        <tr><td height=7></td></tr>\n";
+    }
+
+    echo "        <tr><td height=4 align=left valign=middle class=misc_items>In/Out:</td></tr>\n";
+    echo "        <tr><td height=4 align=left valign=middle class=misc_items>\n";
+
+    // populate dropdown with punchlist items //
+
+    echo "              <select name='left_inout'>\n";
+    echo "              <option value =''>...</option>\n";
+    echo html_options(tc_select("punchitems",  "punchlist"));
+    echo "              </select></td></tr>\n";
+
+    echo "        <tr><td height=7></td></tr>\n";
+    echo "        <tr><td height=4 align=left valign=middle class=misc_items>Notes:</td></tr>\n";
     echo "        <tr><td height=4 align=left valign=middle class=misc_items>";
-    echo "<input type='password' name='employee_passwd' maxlength='25' size='17' tabindex=2></td></tr>\n";
+    echo "<input type='text' name='left_notes' maxlength='250' size='17'></td></tr>\n";
+
+    if (!isset($_COOKIE['remember_me'])) {
+        echo "        <tr><td width=100%><table width=100% border=0 cellpadding=0 cellspacing=0>
+                      <tr><td nowrap height=4 align=left valign=middle class=misc_items width=10%>Remember&nbsp;Me?</td><td width=90% align=left
+                        class=misc_items style='padding-left:0px;padding-right:0px;'><input type='checkbox' name='remember_me' value='1'></td></tr>
+                        </table></td><tr>\n";
+    } elseif (isset($_COOKIE['remember_me'])) {
+        echo "        <tr><td width=100%><table width=100% border=0 cellpadding=0 cellspacing=0>
+                      <tr><td nowrap height=4 align=left valign=middle class=misc_items width=10%>Reset&nbsp;Cookie?</td><td width=90% align=left
+                        class=misc_items style='padding-left:0px;padding-right:0px;'><input type='checkbox' name='reset_cookie' value='1'></td></tr>
+                        </table></td><tr>\n";
+    }
     echo "        <tr><td height=7></td></tr>\n";
 }
 
-echo "        <tr><td height=4 align=left valign=middle class=misc_items>In/Out:</td></tr>\n";
-echo "        <tr><td height=4 align=left valign=middle class=misc_items>\n";
-
-// query to populate dropdown with punchlist items //
-
-$punchlist_result = tc_select("punchitems",  "punchlist");
-
-echo "              <select name='left_inout' tabindex=3>\n";
-echo "              <option value =''>...</option>\n";
-
-while ($row = mysqli_fetch_array($punchlist_result)) {
-    echo "              <option>" . $row['punchitems'] . "</option>\n";
-}
-
-echo "              </select></td></tr>\n";
-((mysqli_free_result($punchlist_result) || (is_object($punchlist_result) && (get_class($punchlist_result) == "mysqli_result"))) ? true : false);
-
-echo "        <tr><td height=7></td></tr>\n";
-echo "        <tr><td height=4 align=left valign=middle class=misc_items>Notes:</td></tr>\n";
-echo "        <tr><td height=4 align=left valign=middle class=misc_items>";
-echo "<input type='text' name='left_notes' maxlength='250' size='17' tabindex=4></td></tr>\n";
-
-if (!isset($_COOKIE['remember_me'])) {
-    echo "        <tr><td width=100%><table width=100% border=0 cellpadding=0 cellspacing=0>
-                  <tr><td nowrap height=4 align=left valign=middle class=misc_items width=10%>Remember&nbsp;Me?</td><td width=90% align=left
-                    class=misc_items style='padding-left:0px;padding-right:0px;' tabindex=5><input type='checkbox' name='remember_me' value='1'></td></tr>
-                    </table></td><tr>\n";
-} elseif (isset($_COOKIE['remember_me'])) {
-    echo "        <tr><td width=100%><table width=100% border=0 cellpadding=0 cellspacing=0>
-                  <tr><td nowrap height=4 align=left valign=middle class=misc_items width=10%>Reset&nbsp;Cookie?</td><td width=90% align=left
-                    class=misc_items style='padding-left:0px;padding-right:0px;' tabindex=5><input type='checkbox' name='reset_cookie' value='1'></td></tr>
-                    </table></td><tr>\n";
-}
-
-echo "        <tr><td height=7></td></tr>\n";
-echo "        <tr><td height=4 align=left valign=middle class=misc_items><input type='submit' name='submit_button' value='Submit' align='center'
-                tabindex=6></td></tr></form>\n";
+echo "        <tr><td height=4 align=left valign=middle class=misc_items><input type='submit' name='submit_button' value='Submit' align='center'></td></tr></form>\n";
 
 
-if ($display_weather == 'yes') {
+if (yes_no_bool($display_weather)) {
     echo '<tr><td>';
     include 'sidebar-metar-display.php';
     echo '</td></tr>';
@@ -191,80 +208,51 @@ if ($request == 'POST') {
 
     // begin post validation //
 
+    # Trying to toggle, look up the "punchnext" toggle state:
+    if (!has_value($inout) and has_value($emp_name)) {
+        $result = tc_query(<<<QUERY
+   SELECT p.punchnext
+     FROM ${db_prefix}employees AS e
+LEFT JOIN ${db_prefix}info      AS i ON (e.empfullname = i.fullname AND e.tstamp = i.timestamp)
+LEFT JOIN ${db_prefix}punchlist AS p ON (i.inout = p.punchitems)
+    WHERE e.$emp_name_field = ?
+QUERY
+        , $emp_name);
+        while ($row = mysqli_fetch_array($result)) {
+            $inout = $row[0];
+        }
+    }
+    elseif (has_value($inout)) {
+        $inout = tc_select_value("punchitems", "punchlist", "punchitems = ?", $inout);
+        if (!has_value($inout)) {
+            echo "In/Out Status is not in the database.\n";
+            exit;
+        }
+    }
+
     if ($use_passwd == "yes") {
         $employee_passwd = crypt($_POST['employee_passwd'], 'xy');
     }
 
-    $punchlist_result = tc_select("punchitems", "punchlist");
-
-    while ($row = mysqli_fetch_array($punchlist_result)) {
-        $tmp_inout = "" . $row['punchitems'] . "";
-    }
-
-    if (!isset($tmp_inout)) {
-        echo "In/Out Status is not in the database.\n";
-        exit;
-    }
-
     // end post validation //
 
-    if ($show_display_name == "yes") {
-
-        if (!$displayname && !$inout) {
-            echo "    <td align=left class=right_main scope=col>\n";
-            echo "      <table width=100% height=100% border=0 cellpadding=10 cellspacing=1>\n";
-            echo "        <tr class=right_main_text>\n";
-            echo "          <td valign=top>\n";
-            echo "<br />\n";
-            echo "You have not chosen a username or a status. Please try again.\n";
-            include 'footer.php';
-            exit;
-        }
-
-        if (!$displayname) {
-            echo "    <td align=left class=right_main scope=col>\n";
-            echo "      <table width=100% height=100% border=0 cellpadding=10 cellspacing=1>\n";
-            echo "        <tr class=right_main_text>\n";
-            echo "          <td valign=top>\n";
-            echo "<br />\n";
-            echo "You have not chosen a username. Please try again.\n";
-            include 'footer.php';
-            exit;
-        }
-
-    } elseif ($show_display_name == "no") {
-
-        if (!$fullname && !$inout) {
-            echo "    <td align=left class=right_main scope=col>\n";
-            echo "      <table width=100% height=100% border=0 cellpadding=10 cellspacing=1>\n";
-            echo "        <tr class=right_main_text>\n";
-            echo "          <td valign=top>\n";
-            echo "<br />\n";
-            echo "You have not chosen a username or a status. Please try again.\n";
-            include 'footer.php';
-            exit;
-        }
-
-        if (!$fullname) {
-            echo "    <td align=left class=right_main scope=col>\n";
-            echo "      <table width=100% height=100% border=0 cellpadding=10 cellspacing=1>\n";
-            echo "        <tr class=right_main_text>\n";
-            echo "          <td valign=top>\n";
-            echo "<br />\n";
-            echo "You have not chosen a username. Please try again.\n";
-            include 'footer.php';
-            exit;
-        }
-
+    if (!has_value($emp_name) && !has_value($inout)) {
+        $errors[] = "You have not chosen a username or a status. Please try again.";
+    }
+    elseif (!has_value($emp_name)) {
+        $errors[] = "You have not chosen a username. Please try again.";
+    }
+    elseif (!has_value($inout)) {
+        $errors[] = "You have not chosen a status. Please try again.";
     }
 
-    if (!$inout) {
+    if (!empty($errors)) {
         echo "    <td align=left class=right_main scope=col>\n";
         echo "      <table width=100% height=100% border=0 cellpadding=10 cellspacing=1>\n";
         echo "        <tr class=right_main_text>\n";
         echo "          <td valign=top>\n";
         echo "<br />\n";
-        echo "You have not chosen a status. Please try again.\n";
+        echo implode("<br>\n", $errors);
         include 'footer.php';
         exit;
     }
@@ -280,10 +268,10 @@ if ($request == 'POST') {
     $year = gmdate('Y', $time);
     $tz_stamp = mktime($hour, $min, $sec, $month, $day, $year);
 
-    if ($use_passwd == "no") {
+    if (has_value($barcode) or $use_passwd == "no") {
 
-        if ($show_display_name == "yes") {
-            $fullname = tc_select_value("empfullname", "employees", "displayname = ?", $displayname);
+        if (!has_value($fullname)) {
+            $fullname = tc_select_value("empfullname", "employees", "$emp_name_field = ?", $emp_name);
         }
 
         $clockin = array("fullname" => $fullname, "inout" => $inout, "timestamp" => $tz_stamp, "notes" => $notes);

--- a/sql/alter_tables.sql
+++ b/sql/alter_tables.sql
@@ -1,6 +1,19 @@
 # if you would like to utilize a table prefix when upgrading these tables, be sure to use the one you have setup in config.inc.php.
 # this option is $db_prefix.  if you are unaware of what is meant by utilizing a 'table prefix', then please disregard.
 
+-- Database upgrades may be performed automatically in the app under
+-- "Administration -> Upgrade Database" as long as the database connection
+-- used by your web app has the required privileges. Otherwise you must
+-- perform the upgrade manually.
+--
+-- When upgrading from versions older than 1.04, perform the upgrades
+-- described in this file in order to reach dbversion 1.4.
+--
+-- To upgrade from dbversion 1.4 or newer, run the upgrade scripts in this
+-- directory, one at a time, until your database is upgraded to the latest
+-- version.
+
+
 
 ###################################################################
 #                                                                 #

--- a/sql/create_tables.sql
+++ b/sql/create_tables.sql
@@ -46,6 +46,7 @@ CREATE TABLE `employees` (
   `employee_passwd` varchar(25) COLLATE utf8_bin NOT NULL DEFAULT '',
   `displayname` varchar(50) COLLATE utf8_bin NOT NULL DEFAULT '',
   `email` varchar(75) COLLATE utf8_bin NOT NULL DEFAULT '',
+  `barcode` varchar(75) COLLATE utf8_bin UNIQUE,
   `groups` varchar(50) COLLATE utf8_bin NOT NULL DEFAULT '',
   `office` varchar(50) COLLATE utf8_bin NOT NULL DEFAULT '',
   `admin` tinyint(1) NOT NULL DEFAULT '0',
@@ -114,6 +115,7 @@ CREATE TABLE `offices` (
 
 CREATE TABLE `punchlist` (
   `punchitems` varchar(50) PRIMARY KEY COLLATE utf8_bin,
+  `punchnext` varchar(50) COLLATE utf8_bin NOT NULL DEFAULT '',
   `color` varchar(7) COLLATE utf8_bin NOT NULL DEFAULT '',
   `in_or_out` tinyint(1) DEFAULT NULL
 ) ENGINE=MyISAM DEFAULT CHARSET=utf8 COLLATE=utf8_bin;
@@ -125,7 +127,7 @@ CREATE TABLE `punchlist` (
 --
 
 INSERT INTO employees VALUES ('admin', NULL, 'xy.RY2HT1QTc2', 'administrator', '', '', '', 1, 1, 1, '');
-INSERT INTO dbversion VALUES ('1.4');
+INSERT INTO dbversion VALUES ('1.5');
 INSERT INTO punchlist VALUES ('in', '#009900', 1);
 INSERT INTO punchlist VALUES ('out', '#FF0000', 0);
 INSERT INTO punchlist VALUES ('break', '#FF9900', 0);

--- a/sql/upgrade_v1.4-v2.0.sql
+++ b/sql/upgrade_v1.4-v2.0.sql
@@ -1,0 +1,5 @@
+
+ALTER TABLE `employees` ADD `barcode`   varchar(75) COLLATE utf8_bin UNIQUE;
+ALTER TABLE `punchlist` ADD `punchnext` varchar(50) COLLATE utf8_bin NOT NULL DEFAULT '';
+
+UPDATE `dbversion` SET `dbversion` = '1.5';


### PR DESCRIPTION
Allow barcode clock-in. This PR includes the database-placeholders changes.

- Add a punchnext field to punchlist table which specifies which punch status should be moved to when we scan our barcode.

- Add a barcode UNIQUE field to the employees table.

- Modify user search to accept barcodes: additionally, I removed the restriction of searching on only a single search term. Terms are now AND-ed together.

- Create new configuration options "$barcode_clockin" and "$manual_clockin" which toggle the display of each login form on the main clock-in screen.

Due to the creation of the "punchnext" property, the In/Out punch field no longer needs to be filled in even for normal punches (provided the "punchnext" fields have been populated by an administrator).

The barcode entry is configured to not auto-complete and is automatically focused on page load, so any barcode scanner or card reader which emulates keyboard input should work fine.